### PR TITLE
Re optimization update

### DIFF
--- a/lenstronomy/LensModel/Optimizer/default_settings.py
+++ b/lenstronomy/LensModel/Optimizer/default_settings.py
@@ -1,0 +1,31 @@
+"""
+This file contains default settings for the optimization class. If the settings are not explicitly specified in the
+call to Optimizer, the setting will default to the parameters in this class
+"""
+
+# the tolerance on lens model source position (used to fit image positions)
+default_tol_source = 1e-5
+# the tolerance on lens model magnification (used to fit magnifications)
+default_tol_mag = 0.2
+# the tolerance on lens model centroid position (used to fit the macromodel centroid; usually can constrain the mass
+# centroid to ~ 50 m.a.s.
+default_tol_centroid = 0.05
+# the tolerance for the Nelder-Mead downhill simplex optimization
+default_tol_simplex = 1e-9
+
+# The standard deviation of the particle swarm particles; when the last few particles have standard deviation below this,
+# the algorithm terminates
+default_pso_convergence_standardDEV = 0.01
+
+# An alternative measure of swarm convergence: if the mean of the penalities associated with the last few lens models
+# is below this value, the swarm terminates. Usually this terminates the particle swarm before the
+# 'pso_convergence_standardDEV' criterion is met
+default_pso_convergence_mean = 2
+
+# The source position penalty below which the magnifications of the lens model will be calculated. This is useful for
+# avoiding the expensive computation of image magnifications for lens models that don't fit the image positions.
+default_pso_compute_magnification = 5
+
+# setting for the particle swarm optimization
+default_n_iterations = 250
+default_n_particles = 50

--- a/lenstronomy/LensModel/Optimizer/fixed_routines.py
+++ b/lenstronomy/LensModel/Optimizer/fixed_routines.py
@@ -15,33 +15,59 @@ class SIE_shear(object):
 
         return {'gamma': self.kwargs_lens[0]['gamma']}
 
-    def get_param_ranges(self):
+    def get_param_ranges(self,reoptimize=False):
 
-        low_e1 = -0.1
-        low_e2 = low_e1
-        hi_e1 = 0.1
-        hi_e2 = hi_e1
+        if reoptimize:
 
-        low_shear_e1 = -0.05
-        high_shear_e1 = 0.05
-        low_shear_e2 = low_shear_e1
-        high_shear_e2 = high_shear_e1
+            e1_e2 = 0.005
+            e1_e2_shear = 0.005
+            theta_E = 0.001
+            center = 0.001
 
-        low_Rein = 0.7
-        hi_Rein = 1.4
+            low_e1 = self.kwargs_lens[0]['e1'] - e1_e2
+            low_e2 = self.kwargs_lens[0]['e2'] - e1_e2
+            hi_e1 = self.kwargs_lens[0]['e1'] + e1_e2
+            hi_e2 = self.kwargs_lens[0]['e2'] + e1_e2
 
-        low_centerx = -0.01
-        hi_centerx = 0.01
-        low_centery = low_centerx
-        hi_centery = hi_centerx
+            low_shear_e1 = self.kwargs_lens[1]['e1'] - e1_e2_shear
+            high_shear_e1 = self.kwargs_lens[1]['e1'] + e1_e2_shear
+            low_shear_e2 = self.kwargs_lens[1]['e2'] - e1_e2_shear
+            high_shear_e2 = self.kwargs_lens[1]['e2'] + e1_e2_shear
+
+            low_Rein = self.kwargs_lens[0]['theta_E'] - theta_E
+            hi_Rein = self.kwargs_lens[0]['theta_E'] + theta_E
+
+            low_centerx = self.kwargs_lens[0]['center_x'] - center
+            hi_centerx = self.kwargs_lens[0]['center_x'] + center
+            low_centery = self.kwargs_lens[0]['center_y'] - center
+            hi_centery = self.kwargs_lens[0]['center_y'] + center
+
+        else:
+
+            low_e1 = -0.1
+            low_e2 = low_e1
+            hi_e1 = 0.1
+            hi_e2 = hi_e1
+
+            low_shear_e1 = -0.05
+            high_shear_e1 = 0.05
+            low_shear_e2 = low_shear_e1
+            high_shear_e2 = high_shear_e1
+
+            low_Rein = 0.7
+            hi_Rein = 1.4
+
+            low_centerx = -0.01
+            hi_centerx = 0.01
+            low_centery = low_centerx
+            hi_centery = hi_centerx
 
         sie_list_low = [low_Rein, low_centerx, low_centery, low_e1, low_e2]
         sie_list_high = [hi_Rein, hi_centerx, hi_centery, hi_e1, hi_e2]
-        shear_list_low = [low_shear_e1,low_shear_e2]
-        shear_list_high = [high_shear_e1,high_shear_e2]
+        shear_list_low = [low_shear_e1, low_shear_e2]
+        shear_list_high = [high_shear_e1, high_shear_e2]
 
         return sie_list_low+shear_list_low,sie_list_high+shear_list_high
-
 
 class SPEP_shear(object):
 
@@ -60,25 +86,52 @@ class SPEP_shear(object):
 
         return {'gamma': self.kwargs_lens[0]['gamma']}
 
-    def get_param_ranges(self):
+    def get_param_ranges(self,reoptimize=False):
 
-        low_e1 = -0.1
-        low_e2 = low_e1
-        hi_e1 = 0.1
-        hi_e2 = hi_e1
+        if reoptimize:
 
-        low_shear_e1 = -0.05
-        high_shear_e1 = 0.05
-        low_shear_e2 = low_shear_e1
-        high_shear_e2 = high_shear_e1
+            e1_e2 = 0.005
+            e1_e2_shear = 0.005
+            theta_E = 0.001
+            center = 0.001
 
-        low_Rein = 0.7
-        hi_Rein = 1.4
+            low_e1 = self.kwargs_lens[0]['e1'] - e1_e2
+            low_e2 = self.kwargs_lens[0]['e2'] - e1_e2
+            hi_e1 = self.kwargs_lens[0]['e1'] + e1_e2
+            hi_e2 = self.kwargs_lens[0]['e2'] + e1_e2
 
-        low_centerx = -0.01
-        hi_centerx = 0.01
-        low_centery = low_centerx
-        hi_centery = hi_centerx
+            low_shear_e1 = self.kwargs_lens[1]['e1'] - e1_e2_shear
+            high_shear_e1 = self.kwargs_lens[1]['e1'] + e1_e2_shear
+            low_shear_e2 = self.kwargs_lens[1]['e2'] - e1_e2_shear
+            high_shear_e2 = self.kwargs_lens[1]['e2'] + e1_e2_shear
+
+            low_Rein = self.kwargs_lens[0]['theta_E'] - theta_E
+            hi_Rein = self.kwargs_lens[0]['theta_E'] + theta_E
+
+            low_centerx = self.kwargs_lens[0]['center_x'] - center
+            hi_centerx = self.kwargs_lens[0]['center_x'] + center
+            low_centery = self.kwargs_lens[0]['center_y'] - center
+            hi_centery = self.kwargs_lens[0]['center_y'] + center
+
+        else:
+
+            low_e1 = -0.1
+            low_e2 = low_e1
+            hi_e1 = 0.1
+            hi_e2 = hi_e1
+
+            low_shear_e1 = -0.05
+            high_shear_e1 = 0.05
+            low_shear_e2 = low_shear_e1
+            high_shear_e2 = high_shear_e1
+
+            low_Rein = 0.7
+            hi_Rein = 1.4
+
+            low_centerx = -0.01
+            hi_centerx = 0.01
+            low_centery = low_centerx
+            hi_centery = hi_centerx
 
         sie_list_low = [low_Rein, low_centerx, low_centery, low_e1, low_e2]
         sie_list_high = [hi_Rein, hi_centerx, hi_centery, hi_e1, hi_e2]

--- a/lenstronomy/LensModel/Optimizer/multi_plane.py
+++ b/lenstronomy/LensModel/Optimizer/multi_plane.py
@@ -7,7 +7,8 @@ class MultiPlaneOptimizer(object):
 
     def __init__(self, lensmodel_full, all_args, x_pos, y_pos, tol_source, Params, magnification_target,
                  tol_mag, centroid_0, tol_centroid, z_main, z_src, astropy_instance, interpolated,return_mode = 'PSO',
-                 mag_penalty=False,return_array = False, verbose=False):
+                 mag_penalty=False,return_array = False, verbose=False,
+                  pso_convergence_mean=None,pso_compute_magnification=None):
 
         self.Params = Params
         self.lensModel = lensmodel_full
@@ -22,6 +23,9 @@ class MultiPlaneOptimizer(object):
         self._compute_mags_flag = mag_penalty
 
         self._return_array = return_array
+
+        self._pso_convergence_mean = pso_convergence_mean
+        self._pso_compute_magnification = pso_compute_magnification
 
         self.centroid_0 = centroid_0
         self.tol_centroid = tol_centroid
@@ -41,7 +45,7 @@ class MultiPlaneOptimizer(object):
 
     def reset(self):
 
-        self.mag_penalty, self.src_penalty, self.parameters = [], [], []
+        self.mag_penalty, self.src_penalty, self.centroid_penalty, self.parameters = [], [], [], []
         self._converged = False
         self._counter = 1
         self._compute_mags = self._compute_mags_flag
@@ -49,7 +53,7 @@ class MultiPlaneOptimizer(object):
 
     def get_best(self):
 
-        total = np.array(self.src_penalty) + np.array(self.mag_penalty)
+        total = np.array(self.src_penalty) + np.array(self.mag_penalty) + np.array(self.centroid_penalty)
 
         return total[np.argmin(total)]
 
@@ -73,7 +77,6 @@ class MultiPlaneOptimizer(object):
     def _source_position_penalty(self, lens_args_tovary):
 
         betax,betay = self.multiplane_optimizer.ray_shooting_fast(lens_args_tovary)
-        self._betax,self._betay = betax,betay
 
         dx = ((betax[0] - betax[1]) ** 2 + (betax[0] - betax[2]) ** 2 + (betax[0] - betax[3]) ** 2 + (
                 betax[1] - betax[2]) ** 2 +
@@ -113,15 +116,18 @@ class MultiPlaneOptimizer(object):
 
         return 0.5 * d_centroid
 
-    def _log(self,src_penalty,mag_penalty):
+    def _log(self,src_penalty,mag_penalty,centroid_penalty):
 
         if mag_penalty is None:
             mag_penalty = np.inf
         if src_penalty is None:
             src_penalty = np.inf
+        if centroid_penalty is None:
+            centroid_penalty = np.inf
 
         self.src_penalty.append(np.sum(src_penalty))
         self.mag_penalty.append(np.sum(mag_penalty))
+        self.centroid_penalty.append(np.sum(centroid_penalty))
         self.parameters.append(self.lens_args_latest)
 
     def _compute_mags_criterion(self):
@@ -129,14 +135,15 @@ class MultiPlaneOptimizer(object):
         if self._compute_mags:
             return True
 
-        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < 5:
+        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < \
+                self._pso_compute_magnification:
             return True
         else:
             return False
 
     def _test_convergence(self):
 
-        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < 1:
+        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < self._pso_convergence_mean:
             self.is_converged = True
         else:
             self.is_converged = False
@@ -185,7 +192,7 @@ class MultiPlaneOptimizer(object):
 
         self.lens_args_latest = lens_args_tovary + params_fixed
 
-        self._log(src_penalty,mag_penalty)
+        self._log(src_penalty,mag_penalty,centroid_penalty)
 
         self._test_convergence()
 

--- a/lenstronomy/LensModel/Optimizer/params.py
+++ b/lenstronomy/LensModel/Optimizer/params.py
@@ -30,7 +30,12 @@ class Params(object):
         self.zlist_tovary,self.lenslist_tovary,self.args_tovary = self.to_vary()
         self.zlist_fixed, self.lenslist_fixed, self.args_fixed = self.fixed()
         self.model_fixed = routine.vary_model_fixed()
-        self.tovary_lower_limit,self.tovary_upper_limit = routine.get_param_ranges()
+
+    def to_vary_limits(self,re_optimize):
+
+        lower_limit,upper_limit = self.routine.get_param_ranges(re_optimize)
+
+        return lower_limit,upper_limit
 
     def to_vary(self):
         zlist_tovary = self.zlist[0:self.Ntovary]
@@ -84,6 +89,17 @@ class Params(object):
 
         return self.args_fixed
 
+    def _kwargs_to_tovary(self,kwargs):
+
+        values = []
+
+        for index in self.tovary_indicies:
+
+            for param_name in self.routine.to_vary_names[index]:
+
+                values.append(kwargs[index][param_name])
+
+        return np.array(values)
 
 
 

--- a/lenstronomy/LensModel/Optimizer/particle_swarm.py
+++ b/lenstronomy/LensModel/Optimizer/particle_swarm.py
@@ -37,7 +37,7 @@ class ParticleSwarmOptimizer(object):
 
         return swarm
 
-    def sample(self, maxIter=1000, c1=1.193, c2=1.193, lookback = 0.25, standard_dev = 0.01):
+    def _sample(self, maxIter=1000, c1=1.193, c2=1.193, lookback = 0.25, standard_dev = None):
         """
         Launches the PSO. Yields the complete swarm per iteration
 
@@ -91,28 +91,24 @@ class ParticleSwarmOptimizer(object):
             i+=1
             self.i = i
 
-    def optimize(self, maxIter=1000, c1=1.193, c2=1.193, lookback=0.25, standard_dev=0.01):
+    def _optimize(self, maxIter=1000, c1=1.193, c2=1.193, lookback=0.25, standard_dev=None):
         """
-        Runs the complete optimiziation.
-
-        :param maxIter: maximum iterations
-        :param c1: cognitive weight
-        :param c2: social weight
-        :param p: stop criterion, percentage of particles to use
-        :param m: stop criterion, difference between mean fitness and global best
-        :param n: stop criterion, difference between norm of the particle vector and norm of the global best
-
-        :return swarms, gBests: the swarms and the global bests of all iterations
+        
+        :param maxIter: maximum number of swarm iterations
+        :param c1: social weight
+        :param c2: personal weight
+        :param lookback: how many particles to assess when considering convergence
+        :param standard_dev: the standard deviation of the last lookback # of particles used to determine convergence
+        :return: 
         """
-
-        #swarms = []
+        
         gBests = []
 
-        for swarm in self.sample(maxIter,c1,c2,lookback,standard_dev):
+        for swarm in self._sample(maxIter, c1, c2, lookback, standard_dev):
 
             #swarms.append(swarm)
             gBests.append(self.gbest.copy())
-        print('done.')
+        print('PSO done.')
         return gBests
 
     def _get_fitness(self,swarm):

--- a/lenstronomy/LensModel/Optimizer/single_plane.py
+++ b/lenstronomy/LensModel/Optimizer/single_plane.py
@@ -6,7 +6,8 @@ class SinglePlaneOptimizer(object):
 
     def __init__(self, lensmodel, x_pos, y_pos, tol_source, params,
                  magnification_target, tol_mag, centroid_0, tol_centroid, k_start=0, arg_list=[],
-                 return_mode='PSO',verbose=False,mag_penalty=False):
+                 return_mode='PSO',verbose=False,mag_penalty=False,pso_convergence_mean=None,
+                 pso_compute_magnification=None):
 
         self.Params = params
         self.lensModel = lensmodel
@@ -20,6 +21,9 @@ class SinglePlaneOptimizer(object):
 
         self.centroid_0 = centroid_0
         self.tol_centroid = tol_centroid
+
+        self._pso_convergence_mean = pso_convergence_mean
+        self._pso_compute_magnification = pso_compute_magnification
 
         self._x_pos, self._y_pos = np.array(x_pos), np.array(y_pos)
 
@@ -53,14 +57,14 @@ class SinglePlaneOptimizer(object):
 
     def reset(self):
 
-        self.mag_penalty, self.src_penalty, self.parameters = [], [], []
+        self.mag_penalty, self.src_penalty, self.parameters, self.centroid_penalty = [], [], [], []
         self._counter = 1
         self._compute_mags = self._compute_mags_flag
         self.is_converged = False
 
     def get_best(self):
 
-        total = np.array(self.src_penalty) + np.array(self.mag_penalty)
+        total = np.array(self.src_penalty) + np.array(self.mag_penalty) + np.array(self.centroid_penalty)
 
         return total[np.argmin(total)]
 
@@ -126,20 +130,23 @@ class SinglePlaneOptimizer(object):
 
     def _centroid_penalty(self, values_dic, tol_centroid):
 
-        dx = (values_dic[0]['center_x'] - self.centroid_0[0])*self.tol_centroid**-1
-        dy = (values_dic[0]['center_y'] - self.centroid_0[1])*self.tol_centroid**-1
+        dx = (values_dic[0]['center_x'] - self.centroid_0[0])*tol_centroid**-1
+        dy = (values_dic[0]['center_y'] - self.centroid_0[1])*tol_centroid**-1
 
         return 0.5*(dx**2+dy**2)
 
-    def _log(self,src_penalty,mag_penalty):
+    def _log(self,src_penalty,mag_penalty,centroid_penalty):
 
         if mag_penalty is None:
             mag_penalty = np.inf
         if src_penalty is None:
             src_penalty = np.inf
+        if centroid_penalty is None:
+            centroid_penalty = np.inf
 
         self.src_penalty.append(src_penalty)
         self.mag_penalty.append(mag_penalty)
+        self.centroid_penalty.append(centroid_penalty)
         self.parameters.append(self.lens_args_latest)
 
     def _compute_mags_criterion(self):
@@ -147,14 +154,16 @@ class SinglePlaneOptimizer(object):
         if self._compute_mags:
             return True
 
-        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < 5:
+        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < \
+                self._pso_compute_magnification:
             return True
         else:
             return False
 
     def _test_convergence(self):
 
-        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < 1:
+        if self._counter > self._n_particles and np.mean(self.src_penalty[-self._n_particles:]) < \
+                self._pso_convergence_mean:
             self.is_converged = True
         else:
             self.is_converged = False
@@ -191,7 +200,7 @@ class SinglePlaneOptimizer(object):
             if self.mag_penalty is not None:
                 print('mag penalty: ', mag_penalty)
         self.lens_args_latest = lens_args_tovary + params_fixed
-        self._log(src_penalty, mag_penalty)
+        self._log(src_penalty, mag_penalty, centroid_penalty)
         self._test_convergence()
         if self._return_mode == 'PSO':
             return -1 * penalty, None

--- a/test/test_LensModel/test_Optimizer/test_single_plane.py
+++ b/test/test_LensModel/test_Optimizer/test_single_plane.py
@@ -31,11 +31,7 @@ class TestSinglePlaneOptimizer(object):
 
     def test_single_plane_simple(self):
 
-        """
-        test the model used to create the data; should be a perfect fit
-        :return:
-        """
-        kwargs_lens, source, [x_image,y_image] = self.optimizer_simple.optimize(n_particles=50,n_iterations=300,restart=2)
+        kwargs_lens, source, [x_image,y_image] = self.optimizer_simple.optimize(restart=2)
         index = sort_image_index(x_image, y_image, self.x_pos_simple, self.y_pos_simple)
 
         x_image = x_image[index]
@@ -50,12 +46,7 @@ class TestSinglePlaneOptimizer(object):
 
     def test_single_plane_subs(self,tol=0.003):
 
-        """
-        test a model with additional subhalos added; should fit images to within a few m.a.s.
-        :param tol:
-        :return:
-        """
-        kwargs_lens, source, [x_image,y_image] = self.optimizer_subs.optimize(n_particles=50,n_iterations=300,restart=2)
+        kwargs_lens, source, [x_image,y_image] = self.optimizer_subs.optimize(restart=2)
         index = sort_image_index(x_image, y_image, self.x_pos_simple, self.y_pos_simple)
         x_image = x_image[index]
         y_image = y_image[index]


### PR DESCRIPTION
The user can specify 're_optimize' which will adjust the initial particle swarm optimization to start clustered around the input 'kwargs_lens' parameters; this speeds up the particle swarm step considerably as long as the starting lens model is reasonably good. There is also a new option 'particle_swarm' that allows the user to skip the particle swarm optimization altogether, and go straight to the downhill simplex optimization. 

I've also added a 'default_settings' file with default parameters used in the optimization. 