### PR TITLE
nfw lookup tables

### DIFF
--- a/lenstronomy/LensModel/Profiles/nfw.py
+++ b/lenstronomy/LensModel/Profiles/nfw.py
@@ -15,12 +15,20 @@ class NFW(object):
     """
     param_names = ['Rs', 'theta_Rs', 'center_x', 'center_y']
 
-    def __init__(self, interpol=False, num_interp_X=1000, max_interp_X=10):
+    def __init__(self, interpol=False, num_interp_X=1000, max_interp_X=10, lookup = False):
         """
 
         :param interpol: bool, if True, interpolates the functions F(), g() and h()
         """
         self._interpol = interpol
+        self._lookup = lookup
+        if lookup and interpol:
+            from lenstronomy.LensModel.Profiles.nfw_lookup import nfw_f, nfw_g, nfw_h, nfw_x
+            self._f_lookup = nfw_f
+            self._h_lookup = nfw_h
+            self._g_lookup = nfw_g
+            self._x_lookup = nfw_x
+
         self._max_interp_X = max_interp_X
         self._num_interp_X = num_interp_X
 
@@ -228,8 +236,13 @@ class NFW(object):
         """
         if self._interpol:
             if not hasattr(self, '_F_interp'):
-                x = np.linspace(0, self._max_interp_X, self._num_interp_X)
-                F_x = self._F(x)
+
+                if self._lookup:
+                    x = self._x_lookup
+                    F_x = self._f_lookup
+                else:
+                    x = np.linspace(0, self._max_interp_X, self._num_interp_X)
+                    F_x = self._F(x)
                 self._F_interp = interp.interp1d(x, F_x, kind='linear', axis=-1, copy=False, bounds_error=False,
                                                  fill_value=0, assume_sorted=True)
             return self._F_interp(X)
@@ -278,8 +291,13 @@ class NFW(object):
         """
         if self._interpol:
             if not hasattr(self, '_g_interp'):
-                x = np.linspace(0, self._max_interp_X, self._num_interp_X)
-                g_x = self._g(x)
+
+                if self._lookup:
+                    x = self._x_lookup
+                    g_x = self._g_lookup
+                else:
+                    x = np.linspace(0, self._max_interp_X, self._num_interp_X)
+                    g_x = self._g(x)
                 self._g_interp = interp.interp1d(x, g_x, kind='linear', axis=-1, copy=False, bounds_error=False,
                                                  fill_value=0, assume_sorted=True)
             return self._g_interp(X)
@@ -324,8 +342,13 @@ class NFW(object):
         """
         if self._interpol:
             if not hasattr(self, '_h_interp'):
-                x = np.linspace(0, self._max_interp_X, self._num_interp_X)
-                h_x = self._h(x)
+
+                if self._lookup:
+                    x = self._x_lookup
+                    h_x = self._h_lookup
+                else:
+                    x = np.linspace(0, self._max_interp_X, self._num_interp_X)
+                    h_x = self._h(x)
                 self._h_interp = interp.interp1d(x, h_x, kind='linear', axis=-1, copy=False, bounds_error=False,
                                                  fill_value=0, assume_sorted=True)
             return self._h_interp(X)
@@ -374,5 +397,3 @@ class NFW(object):
         """
         theta_Rs = rho0 * (4 * Rs ** 2 * (1 + np.log(1. / 2.)))
         return theta_Rs
-
-

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -10,7 +10,8 @@ class LensModel(object):
     class to handle an arbitrary list of lens models
     """
 
-    def __init__(self, lens_model_list, z_lens=None, z_source=None, redshift_list=None, cosmo=None, multi_plane=False):
+    def __init__(self, lens_model_list, z_lens=None, z_source=None, redshift_list=None, cosmo=None,
+                 multi_plane=False, **lensmodel_kwargs):
         """
 
         :param lens_model_list: list of strings with lens model names
@@ -30,9 +31,9 @@ class LensModel(object):
         self.cosmo = cosmo
         self.multi_plane = multi_plane
         if multi_plane is True:
-            self.lens_model = MultiPlane(z_source, lens_model_list, redshift_list, cosmo=cosmo)
+            self.lens_model = MultiPlane(z_source, lens_model_list, redshift_list, cosmo=cosmo, **lensmodel_kwargs)
         else:
-            self.lens_model = SinglePlane(lens_model_list)
+            self.lens_model = SinglePlane(lens_model_list, **lensmodel_kwargs)
         if z_lens is not None and z_source is not None:
             self._lensCosmo = LensCosmo(z_lens, z_source, cosmo=self.cosmo)
 

--- a/lenstronomy/LensModel/multi_plane.py
+++ b/lenstronomy/LensModel/multi_plane.py
@@ -9,7 +9,7 @@ class MultiPlane(object):
     Multi-plane lensing class
     """
 
-    def __init__(self, z_source, lens_model_list, redshift_list, cosmo=None):
+    def __init__(self, z_source, lens_model_list, redshift_list, cosmo=None, **lensmodel_kwargs):
         """
 
         :param cosmo: instance of astropy.cosmology
@@ -28,7 +28,7 @@ class MultiPlane(object):
             self._sorted_redshift_index = []
         else:
             self._sorted_redshift_index = self._index_ordering(redshift_list)
-        self._lens_model = SinglePlane(lens_model_list)
+        self._lens_model = SinglePlane(lens_model_list, **lensmodel_kwargs)
         z_before = 0
         self._T_ij_list = []
         self._T_z_list = []

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -10,7 +10,7 @@ class SinglePlane(object):
     class to handle an arbitrary list of lens models
     """
 
-    def __init__(self, lens_model_list):
+    def __init__(self, lens_model_list, **kwargs):
         """
 
         :param lens_model_list: list of strings with lens model names
@@ -66,7 +66,7 @@ class SinglePlane(object):
                 self.func_list.append(SPEMD_SMOOTH())
             elif lens_type == 'NFW':
                 from lenstronomy.LensModel.Profiles.nfw import NFW
-                self.func_list.append(NFW(interpol=False, num_interp_X=1000, max_interp_X=100))
+                self.func_list.append(NFW(**kwargs))
             elif lens_type == 'NFW_ELLIPSE':
                 from lenstronomy.LensModel.Profiles.nfw_ellipse import NFW_ELLIPSE
                 self.func_list.append(NFW_ELLIPSE(interpol=False, num_interp_X=1000, max_interp_X=100))

--- a/test/test_LensModel/test_Profiles/test_nfw.py
+++ b/test/test_LensModel/test_Profiles/test_nfw.py
@@ -100,18 +100,26 @@ class TestNFW(object):
 
         nfw = NFW(interpol=False)
         nfw_interp = NFW(interpol=True)
+        nfw_interp_lookup = NFW(interpol=True, lookup=True)
 
         values = nfw.function(x, y, Rs, theta_Rs)
         values_interp = nfw_interp.function(x, y, Rs, theta_Rs)
+        values_interp_lookup = nfw_interp_lookup.function(x, y, Rs, theta_Rs)
         npt.assert_almost_equal(values, values_interp, decimal=4)
+        npt.assert_almost_equal(values, values_interp_lookup, decimal=4)
 
         values = nfw.derivatives(x, y, Rs, theta_Rs)
         values_interp = nfw_interp.derivatives(x, y, Rs, theta_Rs)
+        values_interp_lookup = nfw_interp_lookup.derivatives(x, y, Rs, theta_Rs)
         npt.assert_almost_equal(values, values_interp, decimal=4)
+        npt.assert_almost_equal(values, values_interp_lookup, decimal=4)
 
         values = nfw.hessian(x, y, Rs, theta_Rs)
         values_interp = nfw_interp.hessian(x, y, Rs, theta_Rs)
+        values_interp_lookup = nfw_interp_lookup.hessian(x, y, Rs, theta_Rs)
         npt.assert_almost_equal(values, values_interp, decimal=4)
+        npt.assert_almost_equal(values, values_interp_lookup, decimal=4)
+
 
 
 class TestMassAngleConversion(object):

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from lenstronomy.LensModel.lens_model import LensModel
+from lenstronomy.LensModel.Profiles.nfw import NFW
 
 
 class TestLensModel(object):
@@ -21,6 +22,15 @@ class TestLensModel(object):
                             , 'MULTI_GAUSSIAN_KAPPA_ELLIPSE', 'CHAMELEON', 'DOUBLE_CHAMELEON']
         lensModel = LensModel(lens_model_list)
         assert len(lensModel.lens_model_list) == len(lens_model_list)
+
+        lens_model_list = ['NFW']
+        lensModel = LensModel(lens_model_list, interpol = True, lookup=True)
+        x,y = 0.2,1
+        kwargs = [{'theta_Rs':1, 'Rs': 0.5, 'center_x':0, 'center_y':0}]
+        value = lensModel.potential(x,y,kwargs)
+        nfw_interp = NFW(interpol=True, lookup=True)
+        value_interp_lookup = nfw_interp.function(x, y, **kwargs[0])
+        npt.assert_almost_equal(value, value_interp_lookup, decimal=4)
 
     def test_kappa(self):
         output = self.lensModel.kappa(x=1., y=1., kwargs=self.kwargs)


### PR DESCRIPTION
Hi, I've added a python file that contains numpy arrays with the g, h, and F NFW functions interpolated from x = 0 to x = 1000. I need the long range because sometimes subhalos are relatively far away from the position through which I am ray tracing. I've also added some commands that can tell the NFW class to read in the lookup tables rather than interpolating the 3 functions repeatedly, which might speed things up a lot if there are thousands of NFW halos. Unfortunately, the lookup table is somewhat large (7 MB) 