### PR TITLE
update

### DIFF
--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -23,6 +23,8 @@ class LensModel(object):
         only applicable in multi_plane mode.
         :param cosmo: instance of the astropy cosmology class. If not specified, uses the default cosmology.
         :param multi_plane: bool, if True, uses multi-plane mode. Default is False.
+        :param numerical_alpha_class: an instance of a custom class for use in NumericalAlpha() lens model
+        (see documentation in Profiles/numerical_alpha)
         """
         self.lens_model_list = lens_model_list
         self.z_lens = z_lens

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -14,8 +14,7 @@ class SinglePlane(object):
         """
 
         :param lens_model_list: list of strings with lens model names
-        :param numerical_alpha_class: a list of possible custom classes the the user can define
-        to use a grid of precomputed. If not None, should be len(lens_model_list)
+        :param numerical_alpha_class: an instance of a custom class for use in NumericalAlpha() lens model
         deflection angles as a lensmodel. See the documentation in Profiles.numerical_deflections
         """
 
@@ -23,11 +22,6 @@ class SinglePlane(object):
         self._imported_classes = {}
         self._foreground_shear = False
         self._model_list = lens_model_list
-
-        if numerical_alpha_class is not None:
-            if not isinstance(numerical_alpha_class, list) or \
-                    len(numerical_alpha_class) != len(lens_model_list):
-                raise Exception('If specified, numerical_alpha_class must a be list with len(lens_model_list).')
 
         for i, lens_type in enumerate(lens_model_list):
             lensing_function = self._load_lensmodel(lens_type, i, numerical_alpha_class)
@@ -342,7 +336,7 @@ class SinglePlane(object):
             return coreBurkert()
         elif lens_type == 'NumericalAlpha':
             from lenstronomy.LensModel.Profiles.numerical_deflections import NumericalAlpha
-            return NumericalAlpha(custom_class[i])
+            return NumericalAlpha(custom_class)
         else:
             raise ValueError('%s is not a valid lens model' % lens_type)
 

--- a/test/test_LensModel/test_Profiles/test_numerical_deflections.py
+++ b/test/test_LensModel/test_Profiles/test_numerical_deflections.py
@@ -91,7 +91,7 @@ class TestNumericalAlpha(object):
         zlist_single = [0.5, 0.5]
         zlist_multi = [0.5, 0.8]
         zlist = [zlist_single, zlist_multi]
-        numerical_alpha_class = [TestClass(), None]
+        numerical_alpha_class = TestClass()
 
         for i, flag in enumerate([False, True]):
             lensmodel = LensModel(lens_model_list=['NumericalAlpha', 'NFW'], z_source=1.5, z_lens=0.5, lens_redshift_list=zlist[i],
@@ -121,7 +121,7 @@ class TestNumericalAlpha(object):
         zlist_single = [0.5, 0.5]
         zlist_multi = [0.5, 0.8]
         zlist = [zlist_single, zlist_multi]
-        numerical_alpha_class = [TestClass(), None]
+        numerical_alpha_class = TestClass()
 
         for i, flag in enumerate([False, True]):
             lensmodel = LensModel(lens_model_list=['NumericalAlpha', 'NFW'], z_source=1.5, z_lens=0.5,


### PR DESCRIPTION
I changed the expected 'numerical_alpha_class' keyword from a list to a class instance. This is because I split the lens model up into foreground/background in the optimizer, and there isn't a clear cut way to split up the corresponding numerical_alpha_class list. Basically this means that you can only use a single numerical deflection profile per lens model. 