### PR TITLE
Add resuming option for dypolychord with MPI

### DIFF
--- a/lenstronomy/Workflow/fitting_sequence.py
+++ b/lenstronomy/Workflow/fitting_sequence.py
@@ -256,6 +256,11 @@ class FittingSequence(object):
             samples, means, logZ, logZ_err, logL, results_object = sampler.run(kwargs_run)
 
         elif sampler_type == 'DYPOLYCHORD':
+            if 'resume_dyn_run' in kwargs_run and \
+                    kwargs_run['resume_dyn_run'] is True:
+                resume_dyn_run = True
+            else:
+                resume_dyn_run = False
             sampler = DyPolyChordSampler(self.likelihoodModule,
                                          prior_type=prior_type,
                                          prior_means=mean_start,
@@ -265,8 +270,8 @@ class FittingSequence(object):
                                          output_dir=output_dir,
                                          output_basename=output_basename,
                                          polychord_settings=polychord_settings,
-                                         seed_increment=dypolychord_seed_increment,
                                          remove_output_dir=remove_output_dir,
+                                         resume_dyn_run=resume_dyn_run,
                                          use_mpi=self._mpi)
             samples, means, logZ, logZ_err, logL, results_object \
                 = sampler.run(dypolychord_dynamic_goal, kwargs_run)

--- a/test/test_Workflow/test_fitting_sequence.py
+++ b/test/test_Workflow/test_fitting_sequence.py
@@ -221,8 +221,14 @@ class TestFittingSequence(object):
         kwargs_dypolychord = {
             'sampler_type': 'DYPOLYCHORD',
             'kwargs_run': {
-                'ninit': 8,
-                'nlive_const': 10,
+                'ninit': 20,
+                'nlive_const': 30,
+                #'seed_increment': 1,
+                'resume_dyn_run': False,
+                #'init_step': 10,
+            },
+            'polychord_settings': {
+                'seed': 1
             },
             'dypolychord_dynamic_goal': 0.8, # 1 for posterior-only, 0 for evidence-only
             'remove_output_dir': True,

--- a/test/test_Workflow/test_fitting_sequence.py
+++ b/test/test_Workflow/test_fitting_sequence.py
@@ -221,14 +221,15 @@ class TestFittingSequence(object):
         kwargs_dypolychord = {
             'sampler_type': 'DYPOLYCHORD',
             'kwargs_run': {
-                'ninit': 20,
-                'nlive_const': 30,
+                'ninit': 8,
+                'nlive_const': 10,
                 #'seed_increment': 1,
                 'resume_dyn_run': False,
                 #'init_step': 10,
             },
             'polychord_settings': {
-                'seed': 1
+                'seed': 1,
+                #'num_repeats': 20
             },
             'dypolychord_dynamic_goal': 0.8, # 1 for posterior-only, 0 for evidence-only
             'remove_output_dir': True,


### PR DESCRIPTION
- Add ability to resume Polychord sampling.
- Refactor Polychord settings to pass. Use `kwargs_run` to pass keyword arguments to dyPolyChord and `polychord_settings` to pass keyword arguments to Polychord. 