### PR TITLE
Apply ceiling of 0.9999 on ellipticity modulus at an array-level

### DIFF
--- a/lenstronomy/Util/param_util.py
+++ b/lenstronomy/Util/param_util.py
@@ -105,7 +105,6 @@ def ellipticity2phi_q(e1, e2):
     """
     phi = np.arctan2(e2, e1)/2
     c = np.sqrt(e1**2+e2**2)
-    if c > 0.9999:
-        c = 0.9999
+    c = np.minimum(c, 0.9999)
     q = (1-c)/(1+c)
     return phi, q

--- a/test/test_Util/test_param_util.py
+++ b/test/test_Util/test_param_util.py
@@ -32,7 +32,7 @@ def test_polar2cart():
     assert abs(y) < 10e-14
 
 
-def test_phi_q2_elliptisity():
+def test_phi_q2_ellipticity():
     phi, q = 0, 1
     e1,e2 = param_util.phi_q2_ellipticity(phi, q)
     assert e1 == 0
@@ -54,7 +54,7 @@ def test_phi_q2_elliptisity():
     assert e2 == 0
 
 
-def test_elliptisity2phi_q():
+def test_ellipticity2phi_q():
     e1, e2 = 0.3,0
     phi,q = param_util.ellipticity2phi_q(e1, e2)
     assert phi == 0
@@ -67,7 +67,7 @@ def test_elliptisity2phi_q():
     assert np.testing.assert_array_almost_equal(phi, [0.0, 0.39269908], decimal=7)
     assert np.testing.assert_array_almost_equal(q, [0.53846153, 5.00025001e-05], decimal=7)
 
-def test_elliptisity2phi_q_symmetry():
+def test_ellipticity2phi_q_symmetry():
     phi,q = 1.5, 0.8
     e1,e2 = param_util.phi_q2_ellipticity(phi, q)
     phi_new,q_new = param_util.ellipticity2phi_q(e1, e2)

--- a/test/test_Util/test_param_util.py
+++ b/test/test_Util/test_param_util.py
@@ -60,6 +60,12 @@ def test_elliptisity2phi_q():
     assert phi == 0
     assert q == 0.53846153846153844
 
+    # Works on np arrays as well
+    e1 = np.array([0.3, 0.9])
+    e2 = np.array([0.0, 0.9 ])
+    phi, q = param_util.ellipticity2phi_q(e1, e2)
+    assert np.testing.assert_array_almost_equal(phi, [0.0, 0.39269908], decimal=7)
+    assert np.testing.assert_array_almost_equal(q, [0.53846153, 5.00025001e-05], decimal=7)
 
 def test_elliptisity2phi_q_symmetry():
     phi,q = 1.5, 0.8

--- a/test/test_Util/test_param_util.py
+++ b/test/test_Util/test_param_util.py
@@ -64,8 +64,8 @@ def test_ellipticity2phi_q():
     e1 = np.array([0.3, 0.9])
     e2 = np.array([0.0, 0.9 ])
     phi, q = param_util.ellipticity2phi_q(e1, e2)
-    assert np.testing.assert_array_almost_equal(phi, [0.0, 0.39269908], decimal=7)
-    assert np.testing.assert_array_almost_equal(q, [0.53846153, 5.00025001e-05], decimal=7)
+    assert np.allclose(phi, [0.0, 0.39269908], atol=1.e-08)
+    assert np.allclose(q, [0.53846153, 5.00025001e-05], atol=1.e-08)
 
 def test_ellipticity2phi_q_symmetry():
     phi,q = 1.5, 0.8


### PR DESCRIPTION
This is a minor PR so that the function `ellipticity2phi_q` could be used on arrays of `e1`, `e2` as well as floats. Currently, the if condition `if c > 0.9999` throws an error if `c` is an array. I've used a native numpy method to apply this ceiling.