### PR TITLE
Fix CoreSersic profile and make the zero-ing window configurable

### DIFF
--- a/lenstronomy/LensModel/Profiles/sersic_utils.py
+++ b/lenstronomy/LensModel/Profiles/sersic_utils.py
@@ -158,12 +158,13 @@ class SersicUtil(object):
             R[R < self._smoothing] = self._smoothing
         return R
 
-    def _r_sersic(self, R, R_sersic, n_sersic):
+    def _r_sersic(self, R, R_sersic, n_sersic, max_R_frac=100.0):
         """
 
         :param R: radius (array or float)
         :param R_sersic: Sersic radius (half-light radius)
         :param n_sersic: Sersic index (float)
+        :param max_R_frac: maximum window outside of which the mass is zeroed, in units of R_sersic (float)
         :return: Sersic surface brightness at R
         """
 
@@ -172,14 +173,14 @@ class SersicUtil(object):
         R_frac = R_ / R_sersic
         #R_frac = R_frac.astype(np.float32)
         if isinstance(R_, int) or isinstance(R_, float):
-            if R_frac > 100:
+            if R_frac > max_R_frac:
                 result = 0
             else:
                 exponent = -bn * (R_frac ** (1. / n_sersic) - 1.)
                 result = np.exp(exponent)
         else:
-            R_frac_real = R_frac[R_frac <= 100]
+            R_frac_real = R_frac[R_frac <= max_R_frac]
             exponent = -bn * (R_frac_real ** (1. / n_sersic) - 1.)
             result = np.zeros_like(R_)
-            result[R_frac <= 100] = np.exp(exponent)
+            result[R_frac <= max_R_frac] = np.exp(exponent)
         return np.nan_to_num(result)

--- a/lenstronomy/LightModel/Profiles/sersic.py
+++ b/lenstronomy/LightModel/Profiles/sersic.py
@@ -73,31 +73,6 @@ class CoreSersic(SersicUtil):
     upper_limit_default = {'amp': 100, 'Re': 100, 'n_sersic': 8, 'gamma': 10, 'e1': 0.5, 'e2': 0.5, 'center_x': 100,
                            'center_y': 100}
 
-    def function_old(self, x, y, amp, R_sersic, Re, n_sersic, gamma, e1, e2, center_x=0, center_y=0, alpha=3.0, max_R_frac=100.0):
-        """
-        :param x:
-        :param y:
-        :param amp: surface brightness/amplitude value at the half light radius
-        :param R_sersic: semi-major axis half light radius
-        :param Re: "break" core radius
-        :param n_sersic: Sersic index
-        :param gamma: inner power-law exponent
-        :param e1: eccentricity parameter
-        :param e2: eccentricity parameter
-        :param center_x: center in x-coordinate
-        :param center_y: center in y-coordinate
-        :param alpha: sharpness of the transition between the cusp and the outer Sersic profile (float)
-        :param max_R_frac: maximum window outside of which the mass is zeroed, in units of R_sersic (float)
-        :return: Cored Sersic profile value at (x, y)
-        """
-        phi_G, q = param_util.ellipticity2phi_q(e1, e2)
-        R_ = self.get_distance_from_center(x, y, phi_G, q, center_x, center_y)
-        R = self._R_stable(R_)
-        bn = self.b_n(n_sersic)
-        # FIXME: the normalization may be wrong.
-        result = amp * (1 + (R_sersic / R)**alpha)**(gamma/alpha)*np.exp(-bn*(((R** alpha + R_sersic**alpha)/Re**alpha)**(1./(alpha*n_sersic)) - 1.))
-        return np.nan_to_num(result)
-
     def function(self, x, y, amp, R_sersic, Re, n_sersic, gamma, e1, e2, center_x=0, center_y=0, alpha=3.0, max_R_frac=100.0):
         """
         :param x:

--- a/lenstronomy/LightModel/Profiles/sersic.py
+++ b/lenstronomy/LightModel/Profiles/sersic.py
@@ -85,7 +85,18 @@ class CoreSersic(SersicUtil):
 
     def function(self, x, y, amp, R_sersic, Re, n_sersic, gamma, e1, e2, center_x=0, center_y=0, alpha=3.):
         """
-        returns Core-Sersic function
+        :param x:
+        :param y:
+        :param amp: surface brightness/amplitude value at the half light radius
+        :param R_sersic: semi-major axis half light radius
+        :param Re: "break" core radius
+        :param n_sersic: Sersic index
+        :param gamma: inner power-law exponent
+        :param e1: eccentricity parameter
+        :param e2: eccentricity parameter
+        :param center_x: center in x-coordinate
+        :param center_y: center in y-coordinate
+        :return: Cored Sersic profile value at (x, y)
         """
         phi_G, q = param_util.ellipticity2phi_q(e1, e2)
         Rb = R_sersic

--- a/test/test_LightModel/test_Profiles/test_sersic.py
+++ b/test/test_LightModel/test_Profiles/test_sersic.py
@@ -108,18 +108,18 @@ class TestSersic(object):
         center_x = 0
         center_y = 0
         values = self.core_sersic.function(x, y, I0, Rb, Re, n, gamma, e1, e2, center_x, center_y)
-        npt.assert_almost_equal(values[0], 0.84489101, decimal=8)
+        npt.assert_almost_equal(values[0], 0.10338957116342086, decimal=8)
         x = np.array([0])
         y = np.array([0])
         values = self.core_sersic.function(x, y, I0, Rb, Re, n, gamma, e1, e2, center_x, center_y)
-        npt.assert_almost_equal(values[0], 288406.09, decimal=0)
+        npt.assert_almost_equal(values[0], 187852.14004235074, decimal=0)
 
         x = np.array([2,3,4])
         y = np.array([1,1,1])
         values = self.core_sersic.function(x, y, I0, Rb, Re, n, gamma, e1, e2, center_x, center_y)
-        npt.assert_almost_equal(values[0], 0.79749529635325933, decimal=6)
-        npt.assert_almost_equal(values[1], 0.33653478121594838, decimal=6)
-        npt.assert_almost_equal(values[2], 0.14050402887681532, decimal=6)
+        npt.assert_almost_equal(values[0], 0.09255079955772508, decimal=6)
+        npt.assert_almost_equal(values[1], 0.01767817014938002, decimal=6)
+        npt.assert_almost_equal(values[2], 0.0032541063777438853, decimal=6)
 
     def test_total_flux(self):
         r_eff = 0.2


### PR DESCRIPTION
This PR 
- fixes the CoreSersic profile so that it can recover the no core profile (SersicElliptic) when the core radius is set to 0, flattens at the core radius, and has surface brightness `amp` at `R_sersic` away from its center (see blue curve in the plot below).
- parameterizes `max_frac_R`, the window outside of which the lens light is zeroed for numerical stability, so that the user can configure it upon instantiating the light profile. The default is set to the original hardcoded value of 100.0.
- makes some style improvements, e.g. replacing unnecessary scalar vs. array checks with np functions that can work on both and enabling all Sersic profiles to inherit common utility functions in the parent function defined in `sersic_utils.py`.

I've updated the CoreSersic tests in `test/test_LightModel/test_Profiles/test_sersic.py` but the tests `test_surface_brightness_array` and `test_surface_brightness` in `test_LightModel/test_light_model.py` still fail. 

Here is a code snippet that shows that CoreSersic corrected in this PR behaves as expected.
```
from lenstronomy.LightModel.Profiles.sersic import CoreSersic, SersicElliptic
import lenstronomy.Util.param_util as param_util
import numpy as np
import matplotlib.pyplot as plt

common_kwargs = {
    'R_sersic': 1.0,
    'n_sersic': 4.0,
    'e1': 0.1,
    'e2': 0.1,
    'y': 0.0,
    'amp': 1.0,
    'center_x': 0.0,
    'center_y': 0.0
}
Re = 0.2
gamma = 0.0
x_grid = np.linspace(-2.0, 2.0, 100)

core_sersic = CoreSersic()
sersic = SersicElliptic()

# Original CoreSersic
plt.plot(x_grid, core_sersic.function_old(x=x_grid, Re=Re, gamma=gamma, **common_kwargs), color='tab:red', label='lenstronomy original CoreSersic (wrong)')
# SersicElliptic (no core) in lenstronomy
plt.plot(x_grid, sersic.function(x=x_grid, **common_kwargs), color='tab:orange', label='lenstronomy SersicElliptic (no core)')
# Corrected CoreSersic
plt.plot(x_grid, core_sersic.function(x=x_grid, Re=Re, gamma=gamma, **common_kwargs), color='tab:blue', label='lenstronomy new CoreSersic')
# Corrected CoreSersic with Re = 0
plt.scatter(x_grid[::4], core_sersic.function(x=x_grid, Re=0.0, gamma=gamma, **common_kwargs)[::4], color='tab:blue', marker='|', label='new CoreSersic with core radius=0 recovers SersicElliptic.')
# SersicElliptic (no core) in astropy
phi, q = param_util.ellipticity2phi_q(common_kwargs['e1'], common_kwargs['e2'])
astropy_sersic = Sersic2D(amplitude=common_kwargs['amp'], r_eff=common_kwargs['R_sersic'], n=common_kwargs['n_sersic'], x_0=common_kwargs['center_x'], y_0=common_kwargs['center_y'], ellip=1-q, theta=phi)
astropy_sersic_sb = astropy_sersic(x_grid, y=common_kwargs['y'])
plt.scatter(x_grid[::5], astropy_sersic_sb[::5], color='k', marker='.', label='astropy overlaps with lenstronomy SersicElliptic, as it should.')

plt.axhline(common_kwargs['amp'], label='amp', color='k', linestyle='dotted')
plt.axvline(Re, label='core radius', color='k', linestyle='dotted')
plt.axvline(-Re, color='k', linestyle='dotted')
plt.axvline(common_kwargs['R_sersic'], label='outer radius', color='k', linestyle='--')
plt.axvline(-common_kwargs['R_sersic'], color='k', linestyle='--')
plt.legend(loc='center left', bbox_to_anchor=(1, 0.5))
plt.yscale('log')
plt.xlabel('x distance away from center ($^{\prime \prime}$)')
plt.ylabel('amplitude')
plt.title('Core Sersic correction')
```

Output plot:
![image](https://user-images.githubusercontent.com/15166916/74579062-fa14d700-4f4c-11ea-89c5-3e226081f3fe.png)