### PR TITLE
make dynasty sampler optional

### DIFF
--- a/lenstronomy/GalKin/anisotropy.py
+++ b/lenstronomy/GalKin/anisotropy.py
@@ -206,7 +206,8 @@ class GeneralizedOM(object):
     b(r) = beta_inf * r^2 / (r^2 + r_ani^2)
     """
     def __init__(self):
-        self._z_interp = -np.linspace(-100, 0, 100)**2  # z = (R**2 - r**2) / (r_ani**2 + R**2)
+        self._z_interp = np.append(-np.flip(np.logspace(-1, 3, 200)**2), 0)
+        #self._z_interp = -np.linspace(-200, 0, 200)**2  # z = (R**2 - r**2) / (r_ani**2 + R**2)
 
     @staticmethod
     def beta_r(r, r_ani, beta_inf):
@@ -269,7 +270,7 @@ class GeneralizedOM(object):
         """
         if not hasattr(self, '_f_12_interp'):
             f_12_interp = self._F(1 / 2., self._z_interp, beta_inf)
-            self._f_12_interp = interp1d(self._z_interp, f_12_interp, kind='cubic')
+            self._f_12_interp = interp1d(self._z_interp, f_12_interp, kind='cubic', fill_value="extrapolate")
         return self._f_12_interp(z)
 
     def _F_32(self, z, beta_inf):
@@ -281,7 +282,7 @@ class GeneralizedOM(object):
         """
         if not hasattr(self, '_f_32_interp'):
             f_32_interp = self._F(3 / 2., self._z_interp, beta_inf)
-            self._f_32_interp = interp1d(self._z_interp, f_32_interp, kind='cubic')
+            self._f_32_interp = interp1d(self._z_interp, f_32_interp, kind='cubic', fill_value="extrapolate")
         return self._f_32_interp(z)
 
     def _j_beta(self, r, s, r_ani, beta_inf):

--- a/lenstronomy/GalKin/aperture.py
+++ b/lenstronomy/GalKin/aperture.py
@@ -33,7 +33,7 @@ class Aperture(object):
         elif aperture_type == 'IFU_shells':
             self._aperture = IFUShells(**kwargs_aperture)
         else:
-            raise ValueError("aperture type %s not implemented!" % aperture_type)
+            raise ValueError("aperture type %s not implemented! Available are 'slit', 'shell', 'IFU_shells'. " % aperture_type)
 
     def aperture_select(self, ra, dec):
         """

--- a/lenstronomy/GalKin/numeric_kinematics.py
+++ b/lenstronomy/GalKin/numeric_kinematics.py
@@ -49,7 +49,7 @@ class NumericKinematics(Anisotropy):
         """
         I_R_sigma2 = self._I_R_simga2(R, kwargs_mass, kwargs_light, kwargs_anisotropy)
         I_R = self.lightProfile.light_2d(R, kwargs_light)
-        return I_R_sigma2 / I_R
+        return np.nan_to_num(I_R_sigma2 / I_R)
 
     def _I_R_simga2(self, R, kwargs_mass, kwargs_light, kwargs_anisotropy):
         """

--- a/lenstronomy/Sampling/Samplers/base_nested_sampler.py
+++ b/lenstronomy/Sampling/Samplers/base_nested_sampler.py
@@ -37,7 +37,7 @@ class NestedSampler(object):
         self.prior_type = prior_type
         self._has_warned = False
 
-    def prior(self, u):
+    def prior(self, *args, **kwargs):
         """
         compute the mapping between the unit cube and parameter cube
 
@@ -46,7 +46,7 @@ class NestedSampler(object):
         """
         raise NotImplementedError("Method not be implemented in base class")
 
-    def log_likelihood(self, x):
+    def log_likelihood(self, *args, **kwargs):
         """
         compute the log-likelihood given list of parameters
 

--- a/lenstronomy/Sampling/Samplers/dynesty_sampler.py
+++ b/lenstronomy/Sampling/Samplers/dynesty_sampler.py
@@ -39,7 +39,7 @@ class DynestySampler(NestedSampler):
             from schwimmbad import MPIPool
             import sys
 
-            pool = MPIPool()  # use_dill=True not supported
+            pool = MPIPool(use_dill=True)  # use_dill=True not supported for some versions of schwimmbad
             if not pool.is_master():
                 pool.wait()
                 sys.exit(0)

--- a/lenstronomy/Sampling/Samplers/dynesty_sampler.py
+++ b/lenstronomy/Sampling/Samplers/dynesty_sampler.py
@@ -1,7 +1,5 @@
 __author__ = 'aymgal'
 
-import os
-import shutil
 import numpy as np
 
 from lenstronomy.Sampling.Samplers.base_nested_sampler import NestedSampler

--- a/lenstronomy/Sampling/Samplers/dynesty_sampler.py
+++ b/lenstronomy/Sampling/Samplers/dynesty_sampler.py
@@ -60,7 +60,6 @@ class DynestySampler(NestedSampler):
                                                          sample=sample)
         self._has_warned = False
 
-
     def prior(self, u):
         """
         compute the mapping between the unit cube and parameter cube
@@ -75,6 +74,8 @@ class DynestySampler(NestedSampler):
         elif self.prior_type == 'uniform':
             p = utils.cube2args_uniform(u, self.lowers, self.uppers, 
                                         self.n_dims, copy=True)
+        else:
+            raise ValueError('prior type %s not supported! Chose "gaussian" or "uniform".')
         return p
 
     def log_likelihood(self, x):
@@ -91,7 +92,6 @@ class DynestySampler(NestedSampler):
             logL = -1e15
             self._has_warned = True
         return float(logL)
-
 
     def run(self, kwargs_run):
         """

--- a/lenstronomy/Sampling/Samplers/multinest_sampler.py
+++ b/lenstronomy/Sampling/Samplers/multinest_sampler.py
@@ -72,7 +72,6 @@ class MultiNestSampler(NestedSampler):
         self._rm_output = remove_output_dir
         self._has_warned = False
 
-
     def prior(self, cube, ndim, nparams):
         """
         compute the mapping between the unit cube and parameter cube (in-place)
@@ -89,7 +88,6 @@ class MultiNestSampler(NestedSampler):
             utils.cube2args_uniform(cube_py, self.lowers, self.uppers, self.n_dims)
         for i in range(self.n_dims):
             cube[i] = cube_py[i]
-
 
     def log_likelihood(self, args, ndim, nparams):
         """
@@ -156,7 +154,6 @@ class MultiNestSampler(NestedSampler):
             
         return samples, means, logZ, logZ_err, logL, stats
 
-
     def _multinest2python(self, multinest_list, num_dims):
         """convert ctypes list to standard python list"""
         python_list = []
@@ -164,17 +161,15 @@ class MultiNestSampler(NestedSampler):
             python_list.append(multinest_list[i])
         return python_list
 
-
     def _check_install(self):
         try:
             import pymultinest
             from pymultinest.analyse import Analyzer
         except:
             print("Warning : MultiNest/pymultinest not properly installed (results might be unexpected). \
-You can get it from : https://johannesbuchner.github.io/PyMultiNest/pymultinest.html")
+                    You can get it from : https://johannesbuchner.github.io/PyMultiNest/pymultinest.html")
             self._pymultinest_installed = False
         else:
             self._pymultinest_installed = True
             self._pymultinest = pymultinest
             self._Analyzer = Analyzer
-

--- a/test/test_GalKin/test_gom.py
+++ b/test/test_GalKin/test_gom.py
@@ -1,10 +1,11 @@
 from lenstronomy.GalKin.galkin import Galkin
 import numpy.testing as npt
+import numpy as np
 
 
 class TestGOM(object):
     def setup(self):
-        pass
+        np.random.seed(2)
 
     def test_OMvsGOM(self):
         """
@@ -35,7 +36,7 @@ class TestGOM(object):
 
         # anisotropy profile
         anisotropy_type = 'OM'
-        r_ani = 2.
+        r_ani = 0.2
         kwargs_anisotropy = {'r_ani': r_ani}  # anisotropy radius [arcsec]
 
         kwargs_model = {'mass_profile_list': mass_profile_list,
@@ -44,11 +45,11 @@ class TestGOM(object):
         kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
         galkin = Galkin(kwargs_model=kwargs_model, kwargs_aperture=kwargs_aperture, kwargs_psf=kwargs_psf,
                         kwargs_cosmo=kwargs_cosmo, kwargs_numerics=kwargs_numerics)
-        sigma_v_om = galkin.dispersion(kwargs_profile, kwargs_light, kwargs_anisotropy, sampling_number=1000)
+        sigma_v_om = galkin.dispersion(kwargs_profile, kwargs_light, kwargs_anisotropy, sampling_number=5000)
 
         # anisotropy profile
         anisotropy_type = 'GOM'
-        r_ani = 2.
+
         kwargs_anisotropy = {'r_ani': r_ani, 'beta_inf': 1}  # anisotropy radius [arcsec]
 
         kwargs_model = {'mass_profile_list': mass_profile_list,
@@ -57,5 +58,7 @@ class TestGOM(object):
         kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
         galkin_gom = Galkin(kwargs_model=kwargs_model, kwargs_aperture=kwargs_aperture, kwargs_psf=kwargs_psf,
                         kwargs_cosmo=kwargs_cosmo, kwargs_numerics=kwargs_numerics)
-        sigma_v_gom = galkin_gom.dispersion(kwargs_profile, kwargs_light, kwargs_anisotropy, sampling_number=1000)
-        npt.assert_almost_equal(sigma_v_gom, sigma_v_om, decimal=-1)
+        sigma_v_gom = galkin_gom.dispersion(kwargs_profile, kwargs_light, kwargs_anisotropy, sampling_number=5000)
+        # warning: this tests does not work to this precision for every random seed. To increase precision, increase
+        # sampling_number
+        npt.assert_almost_equal(sigma_v_gom, sigma_v_om, decimal=0)


### PR DESCRIPTION
tracks issue #164 
First implementation to make the dynesty sampler optional. We might even consider moving the sampler requirement to a requirement_dev.tex such that it will be installed for testing but not directly when installing lenstronomy.