### PR TITLE
Anisotropy dev

### DIFF
--- a/lenstronomy/Analysis/td_cosmography.py
+++ b/lenstronomy/Analysis/td_cosmography.py
@@ -21,7 +21,7 @@ class TDCosmography(KinematicsAPI):
 
     """
     def __init__(self, z_lens, z_source, kwargs_model, cosmo_fiducial=None, lens_model_kinematics_bool=None,
-                 light_model_kinematics_bool=None):
+                 light_model_kinematics_bool=None, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model=None):
 
         if cosmo_fiducial is None:
             cosmo_fiducial = default_cosmology.get()
@@ -32,7 +32,9 @@ class TDCosmography(KinematicsAPI):
         self.LensModel, self.SourceModel, self.LensLightModel, self.PointSource, extinction_class = class_creator.create_class_instances(all_models=True, **kwargs_model)
         super(TDCosmography, self).__init__(z_lens=z_lens, z_source=z_source, kwargs_model=kwargs_model,
                                             cosmo=cosmo_fiducial, lens_model_kinematics_bool=lens_model_kinematics_bool,
-                                            light_model_kinematics_bool=light_model_kinematics_bool)
+                                            light_model_kinematics_bool=light_model_kinematics_bool,
+                                            kwargs_seeing=kwargs_seeing, kwargs_aperture=kwargs_aperture,
+                                            anisotropy_model=anisotropy_model)
 
     def time_delays(self, kwargs_lens, kwargs_ps, kappa_ext=0):
         """

--- a/lenstronomy/GalKin/anisotropy.py
+++ b/lenstronomy/GalKin/anisotropy.py
@@ -64,7 +64,7 @@ class Anisotropy(object):
         :param kwargs: parameters of the specified anisotropy model
         :return: f(r)
         """
-        self._model.anisotropy_solution(self, r, **kwargs)
+        return self._model.anisotropy_solution(r, **kwargs)
 
     def delete_anisotropy_cache(self):
         """
@@ -251,7 +251,7 @@ class OsipkovMerritt(object):
         See e.g. A5 in Mamon & Lokas
 
         :param r: 3d radius
-        :param kwargs: parameters of the specified anisotropy model
+        :param r_ani: anisotropy radius
         :return: f(r)
         """
         return r**2 + r_ani**2

--- a/lenstronomy/GalKin/anisotropy.py
+++ b/lenstronomy/GalKin/anisotropy.py
@@ -196,7 +196,7 @@ class Radial(object):
         """
         return 1.
 
-    def anisotropy_solution(self, r, **kwargs):
+    def anisotropy_solution(self, r):
         """
         the solution to
         d ln(f)/ d ln(r) = 2 beta(r)
@@ -206,7 +206,7 @@ class Radial(object):
         :param kwargs: parameters of the specified anisotropy model
         :return: f(r)
         """
-        raise ValueError('routine not supported yet for constant anisotropy model!')
+        return r**2
 
 
 class OsipkovMerritt(object):

--- a/lenstronomy/GalKin/anisotropy.py
+++ b/lenstronomy/GalKin/anisotropy.py
@@ -55,6 +55,17 @@ class Anisotropy(object):
         """
         return self._model.K(r, R, **kwargs)
 
+    def anisotropy_solution(self, r, **kwargs):
+        """
+        the solution to
+        d ln(f)/ d ln(r) = 2 beta(r)
+
+        :param r: 3d radius
+        :param kwargs: parameters of the specified anisotropy model
+        :return: f(r)
+        """
+        self._model.anisotropy_solution(self, r, **kwargs)
+
     def delete_anisotropy_cache(self):
         """
         deletes cached interpolations for a fixed anisotropy model
@@ -99,6 +110,17 @@ class Const(object):
         """
         return beta
 
+    def anisotropy_solution(self, r, **kwargs):
+        """
+        the solution to
+        d ln(f)/ d ln(r) = 2 beta(r)
+
+        :param r: 3d radius
+        :param kwargs: parameters of the specified anisotropy model
+        :return: f(r)
+        """
+        raise ValueError('routine not supported yet for constant anisotropy model!')
+
 
 class Isotropic(object):
     """
@@ -131,6 +153,18 @@ class Isotropic(object):
         """
         return 0.
 
+    def anisotropy_solution(self, r, **kwargs):
+        """
+        the solution to
+        d ln(f)/ d ln(r) = 2 beta(r)
+        See e.g. A3 in Mamon & Lokas
+
+        :param r: 3d radius
+        :param kwargs: parameters of the specified anisotropy model
+        :return: f(r)
+        """
+        return 1
+
 
 class Radial(object):
     """
@@ -161,6 +195,18 @@ class Radial(object):
         :return: beta
         """
         return 1.
+
+    def anisotropy_solution(self, r, **kwargs):
+        """
+        the solution to
+        d ln(f)/ d ln(r) = 2 beta(r)
+        See e.g. A4 in Mamon & Lokas
+
+        :param r: 3d radius
+        :param kwargs: parameters of the specified anisotropy model
+        :return: f(r)
+        """
+        raise ValueError('routine not supported yet for constant anisotropy model!')
 
 
 class OsipkovMerritt(object):
@@ -197,6 +243,18 @@ class OsipkovMerritt(object):
         :return: beta
         """
         return r**2/(r_ani**2 + r**2)
+
+    def anisotropy_solution(self, r, r_ani):
+        """
+        the solution to
+        d ln(f)/ d ln(r) = 2 beta(r)
+        See e.g. A5 in Mamon & Lokas
+
+        :param r: 3d radius
+        :param kwargs: parameters of the specified anisotropy model
+        :return: f(r)
+        """
+        return r**2 + r_ani**2
 
 
 class GeneralizedOM(object):

--- a/lenstronomy/GalKin/galkin.py
+++ b/lenstronomy/GalKin/galkin.py
@@ -87,25 +87,6 @@ class Galkin(GalkinObservation):
         self.numerics.delete_cache()
         return np.sqrt(sigma_s2_average) / 1000.  # in units of km/s
 
-    def _draw_one_sigma2(self, kwargs_mass, kwargs_light, kwargs_anisotropy):
-        """
-
-        :param kwargs_mass: mass model parameters (following lenstronomy lens model conventions)
-        :param kwargs_light: deflector light parameters (following lenstronomy light model conventions)
-        :param kwargs_anisotropy: anisotropy parameters, may vary according to anisotropy type chosen.
-            We refer to the Anisotropy() class for details on the parameters.
-        :return: integrated LOS velocity dispersion in angular units for a single draw of the light distribution that
-         falls in the aperture after displacing with the seeing
-        """
-        while True:
-            r, R, x, y = self.numerics.draw_light(kwargs_light)
-            x_, y_ = self.displace_psf(x, y)
-            bool, _ = self.aperture_select(x_, y_)
-            if bool is True:
-                break
-        sigma2_R = self.numerics.sigma_s2(r, R, kwargs_mass, kwargs_light, kwargs_anisotropy)
-        return sigma2_R
-
     def dispersion_map(self, kwargs_mass, kwargs_light, kwargs_anisotropy, num_kin_sampling=1000, num_psf_sampling=100):
         """
         computes the velocity dispersion in each Integral Field Unit
@@ -141,3 +122,22 @@ class Galkin(GalkinObservation):
         # apply unit conversion from arc seconds and deflections to physical velocity dispersion in (km/s)
         self.numerics.delete_cache()
         return np.sqrt(sigma_s2_average) / 1000.  # in units of km/s
+
+    def _draw_one_sigma2(self, kwargs_mass, kwargs_light, kwargs_anisotropy):
+        """
+
+        :param kwargs_mass: mass model parameters (following lenstronomy lens model conventions)
+        :param kwargs_light: deflector light parameters (following lenstronomy light model conventions)
+        :param kwargs_anisotropy: anisotropy parameters, may vary according to anisotropy type chosen.
+            We refer to the Anisotropy() class for details on the parameters.
+        :return: integrated LOS velocity dispersion in angular units for a single draw of the light distribution that
+         falls in the aperture after displacing with the seeing
+        """
+        while True:
+            r, R, x, y = self.numerics.draw_light(kwargs_light)
+            x_, y_ = self.displace_psf(x, y)
+            bool, _ = self.aperture_select(x_, y_)
+            if bool is True:
+                break
+        sigma2_R = self.numerics.sigma_s2(r, R, kwargs_mass, kwargs_light, kwargs_anisotropy)
+        return sigma2_R

--- a/lenstronomy/GalKin/galkin.py
+++ b/lenstronomy/GalKin/galkin.py
@@ -1,11 +1,10 @@
 from lenstronomy.GalKin.observation import GalkinObservation
-from lenstronomy.GalKin.numeric_kinematics import NumericKinematics
-from lenstronomy.GalKin.analytic_kinematics import AnalyticKinematics
+from lenstronomy.GalKin.galkin_model import GalkinModel
 
 import numpy as np
 
 
-class Galkin(GalkinObservation):
+class Galkin(GalkinModel, GalkinObservation):
     """
     Major class to compute velocity dispersion measurements given light and mass models
 
@@ -55,17 +54,9 @@ class Galkin(GalkinObservation):
         :param kwargs_numerics: numerics keyword arguments
         :param analytic_kinematics: bool, if True uses the analytic kinematic model
         """
+        GalkinModel.__init__(self, kwargs_model, kwargs_cosmo, kwargs_numerics=kwargs_numerics,
+                             analytic_kinematics=analytic_kinematics)
         GalkinObservation.__init__(self, kwargs_aperture=kwargs_aperture, kwargs_psf=kwargs_psf)
-        if analytic_kinematics is True:
-            anisotropy_model = kwargs_model.get('anisotropy_model')
-            if not anisotropy_model == 'OM':
-                raise ValueError('analytic kinematics only available for OsipkovMerritt ("OM") anisotropy model.')
-            self.numerics = AnalyticKinematics(kwargs_aperture=kwargs_aperture, kwargs_psf=kwargs_psf,
-                                               kwargs_cosmo=kwargs_cosmo)
-        else:
-            self.numerics = NumericKinematics(kwargs_model=kwargs_model, kwargs_cosmo=kwargs_cosmo, **kwargs_numerics)
-        GalkinObservation.__init__(self, kwargs_aperture=kwargs_aperture, kwargs_psf=kwargs_psf)
-        self._analytic_kinematics = analytic_kinematics
 
     def dispersion(self, kwargs_mass, kwargs_light, kwargs_anisotropy, sampling_number=1000):
         """

--- a/lenstronomy/GalKin/galkin_model.py
+++ b/lenstronomy/GalKin/galkin_model.py
@@ -1,0 +1,84 @@
+from lenstronomy.GalKin.numeric_kinematics import NumericKinematics
+from lenstronomy.GalKin.analytic_kinematics import AnalyticKinematics
+
+
+class GalkinModel(object):
+    """
+    this class handles all the kinematic modeling aspects of Galkin
+    Excluded are observational conditions (seeing, aperture etc)
+    Major class to compute velocity dispersion measurements given light and mass models
+
+    The class supports any mass and light distribution (and superposition thereof) that has a 3d correspondance in their
+    2d lens model distribution. For models that do not have this correspondence, you may want to apply a
+    Multi-Gaussian Expansion (MGE) on their models and use the MGE to be de-projected to 3d.
+
+    The computation follows Mamon&Lokas 2005.
+
+    The class supports various types of anisotropy models (see Anisotropy class).
+    Solving the Jeans Equation requires a numerical integral over the 3d light and mass profile (see Mamon&Lokas 2005).
+    This class (as well as the dedicated LightModel and MassModel classes) perform those integral numerically with an
+    interpolated grid.
+
+    The cosmology assumed to compute the physical mass and distances are set via the kwargs_cosmo keyword arguments.
+        d_d: Angular diameter distance to the deflector (in Mpc)
+        d_s: Angular diameter distance to the source (in Mpc)
+        d_ds: Angular diameter distance from the deflector to the source (in Mpc)
+
+    The numerical options can be chosen through the kwargs_numerics keywords
+
+        interpol_grid_num: number of interpolation points in the light and mass profile (radially). This number should
+        be chosen high enough to accurately describe the true light profile underneath.
+        log_integration: bool, if True, performs the interpolation and numerical integration in log-scale.
+
+        max_integrate: maximum 3d radius to where the numerical integration of the Jeans Equation solver is made.
+        This value should be large enough to contain most of the light and to lead to a converged result.
+        min_integrate: minimal integration value. This value should be very close to zero but some mass and light
+        profiles are diverging and a numerically stable value should be chosen.
+
+    These numerical options should be chosen to allow for a converged result (within your tolerance) but not too
+    conservative to impact too much the computational cost. Reasonable values might depend on the specific problem.
+
+    """
+    def __init__(self, kwargs_model, kwargs_cosmo, kwargs_numerics=None, analytic_kinematics=False):
+        """
+
+        :param kwargs_model: keyword arguments describing the model components
+        :param kwargs_cosmo: keyword arguments that define the cosmology in terms of the angular diameter distances involved
+        :param kwargs_numerics: numerics keyword arguments
+        :param analytic_kinematics: bool, if True uses the analytic kinematic model
+        """
+        if analytic_kinematics is True:
+            anisotropy_model = kwargs_model.get('anisotropy_model')
+            if not anisotropy_model == 'OM':
+                raise ValueError('analytic kinematics only available for OsipkovMerritt ("OM") anisotropy model.')
+            self.numerics = AnalyticKinematics(kwargs_cosmo=kwargs_cosmo)
+        else:
+            if kwargs_numerics is None:
+                kwargs_numerics = {'interpol_grid_num': 1000,  # numerical interpolation, should converge -> infinity
+                                   'log_integration': True,  # log or linear interpolation of surface brightness and mass models
+                                   'max_integrate': 100,
+                                   'min_integrate': 0.001}  # lower/upper bound of numerical integrals
+            self.numerics = NumericKinematics(kwargs_model=kwargs_model, kwargs_cosmo=kwargs_cosmo, **kwargs_numerics)
+        self._analytic_kinematics = analytic_kinematics
+
+    def check_df(self, r, kwargs_mass, kwargs_light, kwargs_anisotropy):
+        """
+        checks whether the phase space distribution function of a given anisotropy model is positive.
+        Currently this is implemented by the relation provided by Ciotti and Morganti 2010 equation (10)
+        https://arxiv.org/pdf/1006.2344.pdf
+
+        :param r: 3d radius to check slope-anisotropy constraint
+        :param theta_E: Einstein radius in arc seconds
+        :param gamma: power-law slope
+        :param a_ani: scaled transition radius of the OM anisotropy distribution
+        :param r_eff: half-light radius in arc seconds
+        :return: equation (10) >= 0 for physical interpretation
+        """
+        dr = 0.01 # finite differential in radial direction
+        r_dr = r + dr
+
+        sigmar2 = self.numerics.sigma_r2(r, kwargs_mass, kwargs_light, kwargs_anisotropy)
+        sigmar2_dr = self.numerics.sigma_r2(r_dr, kwargs_mass, kwargs_light, kwargs_anisotropy)
+        grav_pot = self.numerics.grav_potential(r, kwargs_mass)
+        grav_pot_dr = self.numerics.grav_potential(r_dr, kwargs_mass)
+        return r * (sigmar2_dr - sigmar2 - grav_pot + grav_pot_dr) / dr

--- a/lenstronomy/GalKin/numeric_kinematics.py
+++ b/lenstronomy/GalKin/numeric_kinematics.py
@@ -186,6 +186,18 @@ class NumericKinematics(Anisotropy):
                    const.c ** 2 / (4 * np.pi * const.G)
         return mass_dim
 
+    def grav_potential(self, r, kwargs_mass):
+        """
+        Gravitational potential in SI units
+
+        :param r: radius (arc seconds)
+        :param kwargs_mass:
+        :return: gravitational potential
+        """
+        mass_dim = self.mass_3d(r, kwargs_mass)
+        grav_pot = -const.G * mass_dim / (r * const.arcsec * self.cosmo.dd * const.Mpc)
+        return grav_pot
+
     def draw_light(self, kwargs_light):
         """
 

--- a/lenstronomy/GalKin/numeric_kinematics.py
+++ b/lenstronomy/GalKin/numeric_kinematics.py
@@ -51,6 +51,25 @@ class NumericKinematics(Anisotropy):
         I_R = self.lightProfile.light_2d(R, kwargs_light)
         return np.nan_to_num(I_R_sigma2 / I_R)
 
+    def sigma_r2(self, r, kwargs_mass, kwargs_light, kwargs_anisotropy):
+        """
+        computes numerically the solution of the Jeans equation for a specific 3d radius
+        E.g. Equation (A1) of Mamon & Lokas https://arxiv.org/pdf/astro-ph/0405491.pdf
+        l(r) \sigma_r(r) ^ 2 =  1/f(r) \int_r^{\infty} f(s) l(s) G M(s) / s^2 ds
+        where l(r) is the 3d light profile
+        M(s) is the enclosed 3d mass
+        f is the solution to
+        d ln(f)/ d ln(r) = 2 beta(r)
+
+        :param r: 3d radius
+        :param kwargs_mass: mass model parameters (following lenstronomy lens model conventions)
+        :param kwargs_light: deflector light parameters (following lenstronomy light model conventions)
+        :param kwargs_anisotropy: anisotropy parameters, may vary according to anisotropy type chosen.
+            We refer to the Anisotropy() class for details on the parameters.
+        :return: sigma_r**2
+        """
+        return 1/self._f_anisotropy(r, **kwargs_anisotropy) * self._interpol_integral_jeans(r, kwargs_mass, kwargs_light, kwargs_anisotropy)
+
     def _I_R_simga2(self, R, kwargs_mass, kwargs_light, kwargs_anisotropy):
         """
         equation A15 in Mamon&Lokas 2005 as a logarithmic numerical integral (if option is chosen)

--- a/lenstronomy/GalKin/velocity_util.py
+++ b/lenstronomy/GalKin/velocity_util.py
@@ -112,3 +112,14 @@ def draw_xy(R):
     x = R * np.cos(phi)
     y = R * np.sin(phi)
     return x, y
+
+
+def draw_hernquist(a):
+    """
+
+    :param a: 0.551*r_eff
+    :return: realisation of radius of Hernquist luminosity weighting in 3d
+    """
+    P = np.random.uniform()  # draws uniform between [0,1)
+    r = a*np.sqrt(P)*(np.sqrt(P)+1)/(1-P)  # solves analytically to r from P(r)
+    return r

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -120,6 +120,10 @@ class SinglePlane(ProfileListBase):
         """
         computes the mass within a 3d sphere of radius r
 
+        if you want to have physical units of kg, you need to multiply by this factor:
+        const.arcsec ** 2 * self._cosmo.dd * self._cosmo.ds / self._cosmo.dds * const.Mpc * const.c ** 2 / (4 * np.pi * const.G)
+        grav_pot = -const.G * mass_dim / (r * const.arcsec * self._cosmo.dd * const.Mpc)
+
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the lens model classes
         :param bool_list: list of bools that are part of the output

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -17,9 +17,9 @@ class TestKinematicsAPI(object):
     def test_velocity_dispersion(self):
         z_lens = 0.5
         z_source = 1.5
-        kwargs_options = {'lens_model_list': ['SPEP', 'SHEAR', 'SIS', 'SIS', 'SIS'],
+        kwargs_model = {'lens_model_list': ['SPEP', 'SHEAR', 'SIS', 'SIS', 'SIS'],
                           'lens_light_model_list': ['SERSIC_ELLIPSE', 'SERSIC']}
-        kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options, lens_model_kinematics_bool= [True, False, False, False, False])
+
         theta_E = 1.5
         gamma = 1.8
         kwargs_lens = [{'theta_E': theta_E, 'e1': 0, 'center_x': -0.044798916793300093, 'center_y': 0.0054408937891703788, 'e2': 0, 'gamma': gamma},
@@ -48,6 +48,9 @@ class TestKinematicsAPI(object):
         anisotropy_model = 'OM'
         kwargs_mge = {'n_comp': 20}
         r_eff = 0.211919902322
+        kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_psf,
+                                     lens_model_kinematics_bool=[True, False, False, False, False], anisotropy_model=anisotropy_model)
+
         kinematicAPI._sampling_number = 1000
         v_sigma = kinematicAPI.velocity_dispersion_numerical(kwargs_lens, kwargs_lens_light, kwargs_anisotropy,
                                                          kwargs_aperture, kwargs_psf, anisotropy_model,
@@ -75,7 +78,7 @@ class TestKinematicsAPI(object):
         z_source = 1.5
         kwargs_options = {'lens_light_model_list': ['HERNQUIST_ELLIPSE', 'SERSIC']}
         kwargs_mge = {'n_comp': 20}
-        kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options)
+        kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model='OM')
         r_eff = 0.2
         kwargs_lens_light = [{'amp': 1, 'Rs': r_eff * 0.551, 'e1': 0., 'e2': 0, 'center_x': 0, 'center_y': 0},
                              {'amp': 1, 'R_sersic': 1, 'n_sersic': 2, 'center_x': -10, 'center_y': -10}]
@@ -99,7 +102,7 @@ class TestKinematicsAPI(object):
         z_lens = 0.5
         z_source = 1.5
         kwargs_options = {'lens_model_list': ['SPEP', 'SHEAR']}
-        kin_api = KinematicsAPI(z_lens, z_source, kwargs_options)
+        kin_api = KinematicsAPI(z_lens, z_source, kwargs_options, kwargs_aperture={}, kwargs_seeing={}, anisotropy_model='OM')
         kwargs_lens = [{'theta_E': 1.4272358196260446, 'e1': 0, 'center_x': -0.044798916793300093,
                         'center_y': 0.0054408937891703788, 'e2': 0, 'gamma': 1.8},
                        {'e1': -0.050871696555354479, 'e2': -0.0061601733920590464}
@@ -119,11 +122,10 @@ class TestKinematicsAPI(object):
         np.random.seed(42)
         z_lens = 0.5
         z_source = 1.5
-        kwargs_options = {'lens_model_list': ['SIS'], 'lens_light_model_list': ['HERNQUIST']}
+        kwargs_model = {'lens_model_list': ['SIS'], 'lens_light_model_list': ['HERNQUIST']}
         kwargs_lens = [{'theta_E': 1, 'center_x': 0, 'center_y': 0}]
         kwargs_lens_light = [{'amp': 1, 'Rs': 1, 'center_x': 0, 'center_y': 0}]
         kwargs_anisotropy = {'r_ani': 1}
-        kin_api = KinematicsAPI(z_lens, z_source, kwargs_options)
         # settings
 
         R_slit = 3.8
@@ -133,9 +135,10 @@ class TestKinematicsAPI(object):
                            'angle': 0, 'center_dec': 0}
         psf_fwhm = 0.7
         kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
-        kin_api.kinematic_observation_settings(kwargs_aperture, kwargs_seeing)
-
         anisotropy_model = 'OM'
+        kin_api = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture, kwargs_seeing,
+                                anisotropy_model=anisotropy_model)
+
         kwargs_numerics_galkin = {'interpol_grid_num': 500, 'log_integration': True,
                                   'max_integrate': 10, 'min_integrate': 0.001}
         kin_api.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin, analytic_kinematics=True,
@@ -165,17 +168,16 @@ class TestKinematicsAPI(object):
         kwargs_lens = [{'theta_E': theta_E, 'center_x': 0, 'center_y': 0}]
         kwargs_lens_light = [{'amp': 1, 'Rs': r_eff * 0.551, 'center_x': 0, 'center_y': 0}]
         kwargs_anisotropy = {'r_ani': 1}
-        kin_api = KinematicsAPI(z_lens, z_source, kwargs_options)
-        # settings
 
         r_bins = np.array([0, 0.5, 1])
         aperture_type = 'IFU_shells'
         kwargs_aperture = {'aperture_type': aperture_type, 'center_ra': 0, 'r_bins': r_bins, 'center_dec': 0}
         psf_fwhm = 0.7
         kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
-        kin_api.kinematic_observation_settings(kwargs_aperture, kwargs_seeing)
-
         anisotropy_model = 'OM'
+        kin_api = KinematicsAPI(z_lens, z_source, kwargs_options, kwargs_aperture=kwargs_aperture,
+                                kwargs_seeing=kwargs_seeing, anisotropy_model=anisotropy_model)
+
         kwargs_numerics_galkin = {'interpol_grid_num': 500, 'log_integration': True,
                                   'max_integrate': 10, 'min_integrate': 0.001}
         kin_api.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin, analytic_kinematics=True,
@@ -192,6 +194,52 @@ class TestKinematicsAPI(object):
         print(vel_disp_numerical, vel_disp_analytic)
         npt.assert_almost_equal(vel_disp_numerical, vel_disp_analytic, decimal=-1)
 
+    def test_interpolated_sersic(self):
+        from lenstronomy.Analysis.light2mass import light2mass_interpol
+        kwargs_light = [{'n_sersic': 2, 'R_sersic': 0.5, 'amp': 1, 'center_x': 0.01, 'center_y': 0.01}]
+        kwargs_lens = [{'n_sersic': 2, 'R_sersic': 0.5, 'k_eff': 1, 'center_x': 0.01, 'center_y': 0.01}]
+        deltaPix = 0.1
+        numPix = 100
+
+        kwargs_interp = light2mass_interpol(['SERSIC'], kwargs_lens_light=kwargs_light, numPix=numPix,
+                                                            deltaPix=deltaPix, subgrid_res=5)
+        kwargs_lens_interp = [kwargs_interp]
+        from lenstronomy.Analysis.kinematics_api import KinematicsAPI
+        z_lens = 0.5
+        z_source = 1.5
+        r_ani = 0.62
+        kwargs_anisotropy = {'r_ani': r_ani}
+        R_slit = 3.8
+        dR_slit = 1.
+        aperture_type = 'slit'
+        kwargs_aperture = {'center_ra': 0, 'width': dR_slit, 'length': R_slit, 'angle': 0, 'center_dec': 0, 'aperture_type': aperture_type}
+        psf_fwhm = 0.7
+        kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
+        anisotropy_model = 'OM'
+        r_eff = 0.5
+        kwargs_model = {'lens_model_list': ['SERSIC'],
+                          'lens_light_model_list': ['SERSIC']}
+        kwargs_mge = {'n_comp': 20}
+        kinematic_api = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture, kwargs_seeing=kwargs_psf,
+                                      anisotropy_model=anisotropy_model)
+
+        v_sigma = kinematic_api.velocity_dispersion_numerical(kwargs_lens, kwargs_light, kwargs_anisotropy,
+                                                         kwargs_aperture, kwargs_psf, anisotropy_model,
+                                                         MGE_light=True, MGE_mass=True, r_eff=r_eff, theta_E=1,
+                                                              kwargs_mge_mass=kwargs_mge, kwargs_mge_light=kwargs_mge)
+        kwargs_model_interp = {'lens_model_list': ['INTERPOL'],
+                                 'lens_light_model_list': ['SERSIC']}
+        kinematic_api_interp = KinematicsAPI(z_lens, z_source, kwargs_model_interp, kwargs_aperture, kwargs_seeing=kwargs_psf,
+                                      anisotropy_model=anisotropy_model)
+        v_sigma_interp = kinematic_api_interp.velocity_dispersion_numerical(kwargs_lens_interp, kwargs_light, kwargs_anisotropy,
+                                                         kwargs_aperture, kwargs_psf, anisotropy_model, theta_E=1.,
+                                                         kwargs_numerics={}, MGE_light=True, MGE_mass=True, r_eff=r_eff,
+                                                                            kwargs_mge_mass=kwargs_mge,
+                                                                            kwargs_mge_light=kwargs_mge)
+        npt.assert_almost_equal(v_sigma / v_sigma_interp, 1, 1)
+        # use as kinematic constraints
+        # compare with MGE Sersic kinematic estimate
+
 
 class TestRaise(unittest.TestCase):
 
@@ -199,47 +247,47 @@ class TestRaise(unittest.TestCase):
         with self.assertRaises(ValueError):
             z_lens = 0.5
             z_source = 1.5
-            kwargs_options = {'lens_light_model_list': ['HERNQUIST']}
-            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options)
+            kwargs_model = {'lens_light_model_list': ['HERNQUIST']}
+            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model='OM')
             kwargs_light = [{'Rs': 1, 'amp': 1, 'center_x': 0, 'center_y': 0}]
             kinematicAPI.kinematic_light_profile(kwargs_light, MGE_fit=False,
                                                  Hernquist_approx=True, r_eff=None, model_kinematics_bool=[True])
         with self.assertRaises(ValueError):
             z_lens = 0.5
             z_source = 1.5
-            kwargs_options = {'lens_light_model_list': ['HERNQUIST']}
-            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options)
+            kwargs_model = {'lens_light_model_list': ['HERNQUIST']}
+            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model='OM')
             kwargs_light = [{'Rs': 1, 'amp': 1, 'center_x': 0, 'center_y': 0}]
             kinematicAPI.kinematic_light_profile(kwargs_light, MGE_fit=False,
                                                  Hernquist_approx=False, r_eff=None, analytic_kinematics=True)
         with self.assertRaises(ValueError):
             z_lens = 0.5
             z_source = 1.5
-            kwargs_options = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': []}
-            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options)
+            kwargs_model = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': []}
+            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model='OM')
             kwargs_light = [{'Rs': 1, 'amp': 1, 'center_x': 0, 'center_y': 0}]
             kinematicAPI.kinematic_lens_profiles(kwargs_light, MGE_fit=True, model_kinematics_bool=[True])
         with self.assertRaises(ValueError):
             z_lens = 0.5
             z_source = 1.5
-            kwargs_options = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': []}
-            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options)
+            kwargs_model = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': []}
+            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model='OM')
             kinematicAPI.kinematic_lens_profiles(kwargs_lens=None, analytic_kinematics=True)
 
         with self.assertRaises(ValueError):
             z_lens = 0.5
             z_source = 1.5
-            kwargs_options = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': []}
-            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options)
+            kwargs_model = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': []}
+            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model='OM')
             kwargs_lens_light = [{'Rs': 1, 'center_x': 0, 'center_y': 0}]
             kinematicAPI.kinematic_light_profile(kwargs_lens_light, r_eff=None, MGE_fit=True, model_kinematics_bool=None,
                                     Hernquist_approx=False, kwargs_mge=None)
         with self.assertRaises(ValueError):
             z_lens = 0.5
             z_source = 1.5
-            kwargs_options = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': ['SIS']}
+            kwargs_model = {'lens_light_model_list': ['HERNQUIST'], 'lens_model_list': ['SIS']}
             kwargs_lens = [{'theta_E': 1, 'center_x': 0, 'center_y': 0}]
-            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_options)
+            kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_seeing={}, kwargs_aperture={}, anisotropy_model='OM')
             kinematicAPI.kinematic_lens_profiles(kwargs_lens, MGE_fit=True, model_kinematics_bool=None, theta_E=None,
                                 kwargs_mge={})
 

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -49,7 +49,8 @@ class TestKinematicsAPI(object):
         kwargs_mge = {'n_comp': 20}
         r_eff = 0.211919902322
         kinematicAPI = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_psf,
-                                     lens_model_kinematics_bool=[True, False, False, False, False], anisotropy_model=anisotropy_model)
+                                     lens_model_kinematics_bool=[True, False, False, False, False], anisotropy_model=anisotropy_model,
+                                     kwargs_mge_light={'comp'}, kwargs_mge_mass={'comp'})
 
         kinematicAPI._sampling_number = 1000
         v_sigma = kinematicAPI.velocity_dispersion_numerical(kwargs_lens, kwargs_lens_light, kwargs_anisotropy,

--- a/test/test_Analysis/test_td_cosmography.py
+++ b/test/test_Analysis/test_td_cosmography.py
@@ -18,12 +18,22 @@ class TestTDCosmography(object):
                         'point_source_model_list': ['LENSED_POSITION']}
         z_lens = 0.5
         z_source = 2.5
+
+        R_slit = 3.8
+        dR_slit = 1.
+        aperture_type = 'slit'
+        kwargs_aperture = {'aperture_type': aperture_type, 'center_ra': 0, 'width': dR_slit, 'length': R_slit,
+                           'angle': 0, 'center_dec': 0}
+        psf_fwhm = 0.7
+        kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
+
         TDCosmography(z_lens, z_source, kwargs_model, cosmo_fiducial=None, lens_model_kinematics_bool=None,
-                      light_model_kinematics_bool=None)
+                      light_model_kinematics_bool=None, kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_seeing)
         from astropy.cosmology import FlatLambdaCDM
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
         self.td_cosmo = TDCosmography(z_lens, z_source, kwargs_model, cosmo_fiducial=cosmo, lens_model_kinematics_bool=None,
-                 light_model_kinematics_bool=None)
+                                      kwargs_aperture = kwargs_aperture, kwargs_seeing = kwargs_seeing,
+                                      light_model_kinematics_bool=None)
         self.lens = LensModel(lens_model_list=['SIE'], cosmo=cosmo, z_lens=z_lens, z_source=z_source)
         self.solver = LensEquationSolver(lensModel=self.lens)
 
@@ -69,15 +79,6 @@ class TestTDCosmography(object):
         r_eff = 0.5
         kwargs_lens_light = [{'Rs': r_eff * 0.551, 'center_x': 0, 'center_y': 0}]
         kwargs_anisotropy = {'r_ani': 1}
-
-        R_slit = 3.8
-        dR_slit = 1.
-        aperture_type = 'slit'
-        kwargs_aperture = {'aperture_type': aperture_type, 'center_ra': 0, 'width': dR_slit, 'length': R_slit,
-                           'angle': 0, 'center_dec': 0}
-        psf_fwhm = 0.7
-        kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
-        self.td_cosmo.kinematic_observation_settings(kwargs_aperture, kwargs_seeing)
 
         anisotropy_model = 'OM'
         kwargs_numerics_galkin = {'interpol_grid_num': 500, 'log_integration': True,

--- a/test/test_GalKin/test_analytic_kinematics.py
+++ b/test/test_GalKin/test_analytic_kinematics.py
@@ -12,34 +12,12 @@ class TestAnalyticKinematics(object):
                            'aperture_type': 'slit'}
         kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
         kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': 1}
-        kin = AnalyticKinematics(kwargs_aperture, kwargs_psf, kwargs_cosmo)
+        kin = AnalyticKinematics(kwargs_cosmo)
         kwargs_light = {'r_eff': 1}
         sigma_s2 = kin.sigma_s2(r=1, R=0.1, kwargs_mass={'theta_E': 1, 'gamma': 2}, kwargs_light=kwargs_light,
                                 kwargs_anisotropy={'r_ani': 1})
         assert 'a' in kwargs_light
 
-    def test_radius_slope_anisotropy(self):
-        kwargs_aperture = {'center_ra': 0, 'width': 1, 'length': 1, 'angle': 0, 'center_dec': 0,
-                           'aperture_type': 'slit'}
-        kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
-        kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': 1}
-        kin = AnalyticKinematics(kwargs_aperture, kwargs_psf, kwargs_cosmo)
-        r = 1
-        theta_E, gamma = 1, 2.
-        a_ani = 10
-        r_eff = 0.1
-        out = kin.check_df(r, theta_E, gamma, a_ani, r_eff)
-        assert out > 0
-        print(out)
-        #import matplotlib.pyplot as plt
-        #import numpy as np
-        #r_list = np.logspace(-1, 1, 20)
-        #crit_list = []
-        #for r in r_list:
-        #    crit_list.append(kin.check_df(r, theta_E, gamma, a_ani, r_eff))
-        #plt.plot(r_list, crit_list)
-        #plt.show()
-        #assert 1 == 0
 
 
 if __name__ == '__main__':

--- a/test/test_GalKin/test_analytic_kinematics.py
+++ b/test/test_GalKin/test_analytic_kinematics.py
@@ -18,6 +18,29 @@ class TestAnalyticKinematics(object):
                                 kwargs_anisotropy={'r_ani': 1})
         assert 'a' in kwargs_light
 
+    def test_radius_slope_anisotropy(self):
+        kwargs_aperture = {'center_ra': 0, 'width': 1, 'length': 1, 'angle': 0, 'center_dec': 0,
+                           'aperture_type': 'slit'}
+        kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
+        kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': 1}
+        kin = AnalyticKinematics(kwargs_aperture, kwargs_psf, kwargs_cosmo)
+        r = 1
+        theta_E, gamma = 1, 2.
+        a_ani = 10
+        r_eff = 0.1
+        out = kin.check_df(r, theta_E, gamma, a_ani, r_eff)
+        assert out > 0
+        print(out)
+        #import matplotlib.pyplot as plt
+        #import numpy as np
+        #r_list = np.logspace(-1, 1, 20)
+        #crit_list = []
+        #for r in r_list:
+        #    crit_list.append(kin.check_df(r, theta_E, gamma, a_ani, r_eff))
+        #plt.plot(r_list, crit_list)
+        #plt.show()
+        #assert 1 == 0
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_GalKin/test_anisotropy.py
+++ b/test/test_GalKin/test_anisotropy.py
@@ -79,15 +79,17 @@ class TestAnisotropy(object):
         # radial
         r = 2.
         R = 1.
-        anisoClass = Anisotropy(anisotropy_type='radial')
-        kwargs = {}
-        beta = anisoClass.beta_r(r, **kwargs)
-        k = anisoClass.K(r, R, **kwargs)
-        anisoClassMamon = Anisotropy(anisotropy_type='const')
+        radial = Anisotropy(anisotropy_type='radial')
+        kwargs_rad = {}
+        beta = radial.beta_r(r, **kwargs_rad)
+        k = radial.K(r, R, **kwargs_rad)
+        f = radial.anisotropy_solution(r, **kwargs_rad)
+        assert f == r**2
+        const = Anisotropy(anisotropy_type='const')
         kwargs = {'beta': beta}
         print(beta, 'beta')
         #kwargs = {'beta': 1}
-        k_mamon = anisoClassMamon.K(r, R, **kwargs)
+        k_mamon = const.K(r, R, **kwargs)
         print(k, k_mamon)
         npt.assert_almost_equal(k, k_mamon, decimal=5)
 
@@ -96,32 +98,40 @@ class TestAnisotropy(object):
         # radial
         r = 2.
         R = 1.
-        anisoClass = Anisotropy(anisotropy_type='isotropic')
-        kwargs = {}
-        beta = anisoClass.beta_r(r, **kwargs)
-        k = anisoClass.K(r, R, **kwargs)
+        isotropic = Anisotropy(anisotropy_type='isotropic')
+        kwargs_iso = {}
+        beta = isotropic.beta_r(r, **kwargs_iso)
+        k = isotropic.K(r, R, **kwargs_iso)
+        f = isotropic.anisotropy_solution(r, **kwargs_iso)
+        assert f == 1
         print(beta, 'test')
-        anisoClassMamon = Anisotropy(anisotropy_type='const')
+        const = Anisotropy(anisotropy_type='const')
         kwargs = {'beta': beta}
-        k_mamon = anisoClassMamon.K(r, R, **kwargs)
-        print(k, k_mamon)
-        npt.assert_almost_equal(k, k_mamon, decimal=5)
+        k_const = const.K(r, R, **kwargs)
+        print(k, k_const)
+        npt.assert_almost_equal(k, k_const, decimal=5)
 
     def test_generalizedOM(self):
         # generalized OM model
-        anisoClass = Anisotropy(anisotropy_type='GOM')
+        gom = Anisotropy(anisotropy_type='GOM')
         r = self._r_array
         R = 2
-        anisoClassOM = Anisotropy(anisotropy_type='OM')
+        om = Anisotropy(anisotropy_type='OM')
         kwargs_om = {'r_ani': 1.}
         kwargs_gom = {'r_ani': 1., 'beta_inf': 1.}
-        beta_gom = anisoClass.beta_r(r, **kwargs_gom)
-        beta_om = anisoClassOM.beta_r(r, **kwargs_om)
+        beta_gom = gom.beta_r(r, **kwargs_gom)
+        beta_om = om.beta_r(r, **kwargs_om)
         npt.assert_almost_equal(beta_gom, beta_om, decimal=5)
 
-        K_gom = anisoClass.K(r, R, **kwargs_gom)
-        K_om = anisoClassOM.K(r, R, **kwargs_om)
+        K_gom = gom.K(r, R, **kwargs_gom)
+        K_om = om.K(r, R, **kwargs_om)
         npt.assert_almost_equal(K_gom, K_om, decimal=3)
+
+        from lenstronomy.GalKin.anisotropy import GeneralizedOM
+        gom_class = GeneralizedOM()
+        _F = gom_class._F(a=3/2., z=0.5, beta_inf=1)
+        _F_array = gom_class._F(a=3 / 2., z=np.array([0.5]), beta_inf=1)
+        npt.assert_almost_equal(_F_array[0], _F, decimal=5)
 
 
 class TestRaise(unittest.TestCase):
@@ -132,6 +142,15 @@ class TestRaise(unittest.TestCase):
         with self.assertRaises(ValueError):
             ani = Anisotropy(anisotropy_type='Colin')
             ani.K(r=1, R=2, r_ani=1)
+
+        with self.assertRaises(ValueError):
+            ani = Anisotropy(anisotropy_type='const')
+            ani.anisotropy_solution(r=1)
+
+        with self.assertRaises(ValueError):
+            const = Anisotropy(anisotropy_type='const')
+            kwargs = {'beta': 1}
+            f_const = const.anisotropy_solution(r=1, **kwargs)
 
 
 if __name__ == '__main__':

--- a/test/test_GalKin/test_galkin.py
+++ b/test/test_GalKin/test_galkin.py
@@ -50,8 +50,8 @@ class TestGalkin(object):
     def test_log_linear_integral(self):
         # light profile
         light_profile_list = ['HERNQUIST']
-        r_eff = .5
-        kwargs_light = [{'Rs':  r_eff, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
+        Rs = .5
+        kwargs_light = [{'Rs':  Rs, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
         # 0.551 *
         # mass profile
         mass_profile_list = ['SPP']
@@ -95,8 +95,8 @@ class TestGalkin(object):
     def test_log_vs_linear_integral(self):
         # light profile
         light_profile_list = ['HERNQUIST']
-        r_eff = .5
-        kwargs_light = [{'Rs':  r_eff, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
+        Rs = .5
+        kwargs_light = [{'Rs':  Rs, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
         # 0.551 *
         # mass profile
         mass_profile_list = ['SPP']
@@ -145,7 +145,7 @@ class TestGalkin(object):
         # light profile
         light_profile_list = ['HERNQUIST']
         r_eff = 1.5
-        kwargs_light = [{'Rs':  r_eff, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
+        kwargs_light = [{'Rs':  0.551 * r_eff, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
         # 0.551 *
         # mass profile
         mass_profile_list = ['SPP']
@@ -183,7 +183,7 @@ class TestGalkin(object):
         sigma_v_lin = galkin.dispersion(kwargs_profile, kwargs_light, kwargs_anisotropy, sampling_number=1000)
 
         los_disp = AnalyticKinematics(kwargs_aperture=kwargs_aperture, kwargs_psf=kwargs_psf, kwargs_cosmo=kwargs_cosmo)
-        sigma_v2 = los_disp.dispersion(gamma, theta_E, r_eff / 0.551, r_ani=r_ani,
+        sigma_v2 = los_disp.dispersion(gamma, theta_E, r_eff, r_ani=r_ani,
                                        sampling_number=1000)
         print(sigma_v, sigma_v_lin, sigma_v2, 'sigma_v Galkin (log and linear), sigma_v los dispersion')
         npt.assert_almost_equal(sigma_v2/sigma_v, 1, decimal=2)
@@ -208,10 +208,10 @@ class TestGalkin(object):
         :return:
         """
         light_profile_list = ['HERNQUIST_ELLIPSE']
-        r_eff = 1.
+        Rs = 1.
         phi, q = 1, 0.8
         e1, e2 = param_util.phi_q2_ellipticity(phi, q)
-        kwargs_light = [{'Rs': r_eff, 'amp': 1.,'e1': e1, 'e2': e2}]  # effective half light radius (2d projected) in arcsec
+        kwargs_light = [{'Rs': Rs, 'amp': 1.,'e1': e1, 'e2': e2}]  # effective half light radius (2d projected) in arcsec
         lightProfile = LightProfile(light_profile_list)
         R = 2
         light2d = lightProfile.light_2d(R=R, kwargs_list=kwargs_light)

--- a/test/test_GalKin/test_galkin_model.py
+++ b/test/test_GalKin/test_galkin_model.py
@@ -1,0 +1,48 @@
+__author__ = 'sibirrer'
+from lenstronomy.GalKin.galkin_model import GalkinModel
+
+
+import numpy.testing as npt
+import numpy as np
+import pytest
+import unittest
+
+
+class TestGalkinModel(object):
+
+    def setup(self):
+        pass
+
+    def test_radius_slope_anisotropy(self):
+
+        kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
+        kwargs_model = {'anisotropy_model': 'OM', 'mass_profile_list': ['SPP'], 'light_profile_list': ['HERNQUIST']}
+
+        kin_analytic = GalkinModel(kwargs_model, kwargs_cosmo, analytic_kinematics=True)
+        r = 1
+        theta_E, gamma = 1, 2.
+        a_ani = 10
+        r_eff = 0.1
+        out = kin_analytic.check_df(r, kwargs_mass={'theta_E': theta_E, 'gamma': gamma}, kwargs_light={'r_eff': r_eff},
+                           kwargs_anisotropy={'r_ani': a_ani*r_eff})
+        assert out > 0
+        print(out)
+
+        kin_numeric = GalkinModel(kwargs_model, kwargs_cosmo, analytic_kinematics=False)
+        out_num = kin_numeric.check_df(r, kwargs_mass=[{'theta_E': theta_E, 'gamma': gamma}],
+                                       kwargs_light=[{'Rs': r_eff * 0.551, 'amp': 1}], kwargs_anisotropy={'r_ani': a_ani*r_eff})
+        assert out_num > 1
+        npt.assert_almost_equal(out_num/out, 1, decimal=2)
+        # import matplotlib.pyplot as plt
+        # import numpy as np
+        # r_list = np.logspace(-1, 1, 20)
+        # crit_list = []
+        # for r in r_list:
+        #    crit_list.append(kin.check_df(r, theta_E, gamma, a_ani, r_eff))
+        # plt.plot(r_list, crit_list)
+        # plt.show()
+        # assert 1 == 0
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/test/test_GalKin/test_light_profile.py
+++ b/test/test_GalKin/test_light_profile.py
@@ -20,7 +20,7 @@ class TestLightProfile(object):
         kwargs_profile = [{'amp': 1., 'Rs': 0.8}]
         r_list = lightProfile.draw_light_2d(kwargs_profile, n=500000)
         bins = np.linspace(0., 1, 20)
-        hist, bins_hist = np.histogram(r_list, bins=bins, normed=True)
+        hist, bins_hist = np.histogram(r_list, bins=bins, density=True)
         light2d = lightProfile.light_2d(R=(bins_hist[1:] + bins_hist[:-1])/2., kwargs_list=kwargs_profile)
         light2d *= (bins_hist[1:] + bins_hist[:-1]) / 2.
         light2d /= np.sum(light2d)
@@ -36,7 +36,7 @@ class TestLightProfile(object):
         kwargs_profile = [{'amp': 1., 'Rs': 0.8}]
         r_list = lightProfile.draw_light_2d_linear(kwargs_profile, n=100000)
         bins = np.linspace(0., 1, 20)
-        hist, bins_hist = np.histogram(r_list, bins=bins, normed=True)
+        hist, bins_hist = np.histogram(r_list, bins=bins, density=True)
         light2d = lightProfile.light_2d(R=(bins_hist[1:] + bins_hist[:-1])/2., kwargs_list=kwargs_profile)
         light2d_upper = lightProfile.light_2d(R=bins_hist[1:], kwargs_list=kwargs_profile) * bins_hist[1:]
         light2d_lower = lightProfile.light_2d(R=bins_hist[:-1], kwargs_list=kwargs_profile) * bins_hist[:-1]
@@ -55,7 +55,7 @@ class TestLightProfile(object):
         kwargs_profile = [{'amp': 1., 'Rs': 0.5, 'Ra': 0.2}]
         r_list = lightProfile.draw_light_2d(kwargs_profile, n=100000)
         bins = np.linspace(0, 2, 10)
-        hist, bins_hist = np.histogram(r_list, bins=bins, normed=True)
+        hist, bins_hist = np.histogram(r_list, bins=bins, density=True)
         light2d = lightProfile.light_2d(R=(bins_hist[1:] + bins_hist[:-1])/2., kwargs_list=kwargs_profile)
         light2d *= (bins_hist[1:] + bins_hist[:-1]) / 2.
         light2d /= np.sum(light2d)
@@ -67,7 +67,7 @@ class TestLightProfile(object):
         kwargs_profile = [{'amp': 1., 'Rs': 0.04, 'Ra': 0.02}]
         r_list = lightProfile.draw_light_2d(kwargs_profile, n=100000)
         bins = np.linspace(0., 0.1, 10)
-        hist, bins_hist = np.histogram(r_list, bins=bins, normed=True)
+        hist, bins_hist = np.histogram(r_list, bins=bins, density=True)
         light2d = lightProfile.light_2d(R=(bins_hist[1:] + bins_hist[:-1])/2., kwargs_list=kwargs_profile)
         light2d *= (bins_hist[1:] + bins_hist[:-1]) / 2.
         light2d /= np.sum(light2d)

--- a/test/test_GalKin/test_numeric_kinematics.py
+++ b/test/test_GalKin/test_numeric_kinematics.py
@@ -2,9 +2,11 @@
 Tests for `Galkin` module.
 """
 import pytest
+import numpy as np
 import numpy.testing as npt
 
 from lenstronomy.GalKin.numeric_kinematics import NumericKinematics
+from lenstronomy.GalKin.analytic_kinematics import AnalyticKinematics
 
 
 class TestMassProfile(object):
@@ -29,7 +31,57 @@ class TestMassProfile(object):
 
         :return:
         """
-        pass
+        light_profile_list = ['HERNQUIST']
+        r_eff = 1.5
+        Rs = 0.551 * r_eff
+        kwargs_light = [{'Rs': Rs, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
+        # 0.551 *
+        # mass profile
+        mass_profile_list = ['SPP']
+        theta_E = 1.2
+        gamma = 2.
+        kwargs_mass = [{'theta_E': theta_E, 'gamma': gamma}]  # Einstein radius (arcsec) and power-law slope
+
+        # anisotropy profile
+        anisotropy_type = 'OM'
+        r_ani = 2.
+        kwargs_anisotropy = {'r_ani': r_ani}  # anisotropy radius [arcsec]
+
+        # aperture as slit
+        aperture_type = 'slit'
+        length = 3.8
+        width = 0.9
+        kwargs_aperture = {'aperture_type': aperture_type, 'length': length, 'width': width, 'center_ra': 0,
+                           'center_dec': 0, 'angle': 0}
+
+        psf_fwhm = 0.7  # Gaussian FWHM psf
+        kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
+        kwargs_numerics = {'interpol_grid_num': 500, 'log_integration': True,
+                               'max_integrate': 100}
+
+        kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
+        kwargs_model = {'mass_profile_list': mass_profile_list,
+                        'light_profile_list': light_profile_list,
+                        'anisotropy_model': anisotropy_type}
+        analytic_kin = AnalyticKinematics(kwargs_aperture, kwargs_psf, kwargs_cosmo)
+        numeric_kin = NumericKinematics(kwargs_model, kwargs_cosmo, **kwargs_numerics)
+        rho0_r0_gamma = analytic_kin._rho0_r0_gamma(theta_E, gamma)
+        r_array = np.logspace(-2, 0.5, 10)
+        sigma_r_analytic_array = []
+        sigma_r_num_array = []
+        for r in r_array:
+            sigma_r2_analytic = analytic_kin.sigma_r2(r=r, a=Rs, gamma=gamma, r_ani=r_ani, rho0_r0_gamma=rho0_r0_gamma)
+            sigma_r2_num = numeric_kin.sigma_r2(r, kwargs_mass, kwargs_light, kwargs_anisotropy)
+            sigma_r_analytic = np.sqrt(sigma_r2_analytic) / 1000
+            sigma_r_num = np.sqrt(sigma_r2_num) / 1000
+            sigma_r_num_array.append(sigma_r_num)
+            sigma_r_analytic_array.append(sigma_r_analytic)
+        #import matplotlib.pyplot as plt
+        #plt.semilogx(r_array, np.array(sigma_r_analytic_array)/np.array(sigma_r_num_array), label='analytic')
+        #plt.semilogx(r_array, sigma_r_num_array, label='numeric')
+        #plt.legend()
+        #plt.show()
+        npt.assert_almost_equal(sigma_r_num_array, sigma_r_analytic_array, decimal=-1)
 
 
 if __name__ == '__main__':

--- a/test/test_GalKin/test_numeric_kinematics.py
+++ b/test/test_GalKin/test_numeric_kinematics.py
@@ -47,30 +47,21 @@ class TestMassProfile(object):
         r_ani = 2.
         kwargs_anisotropy = {'r_ani': r_ani}  # anisotropy radius [arcsec]
 
-        # aperture as slit
-        aperture_type = 'slit'
-        length = 3.8
-        width = 0.9
-        kwargs_aperture = {'aperture_type': aperture_type, 'length': length, 'width': width, 'center_ra': 0,
-                           'center_dec': 0, 'angle': 0}
-
-        psf_fwhm = 0.7  # Gaussian FWHM psf
         kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
         kwargs_numerics = {'interpol_grid_num': 500, 'log_integration': True,
                                'max_integrate': 100}
 
-        kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
         kwargs_model = {'mass_profile_list': mass_profile_list,
                         'light_profile_list': light_profile_list,
                         'anisotropy_model': anisotropy_type}
-        analytic_kin = AnalyticKinematics(kwargs_aperture, kwargs_psf, kwargs_cosmo)
+        analytic_kin = AnalyticKinematics(kwargs_cosmo)
         numeric_kin = NumericKinematics(kwargs_model, kwargs_cosmo, **kwargs_numerics)
         rho0_r0_gamma = analytic_kin._rho0_r0_gamma(theta_E, gamma)
         r_array = np.logspace(-2, 0.5, 10)
         sigma_r_analytic_array = []
         sigma_r_num_array = []
         for r in r_array:
-            sigma_r2_analytic = analytic_kin.sigma_r2(r=r, a=Rs, gamma=gamma, r_ani=r_ani, rho0_r0_gamma=rho0_r0_gamma)
+            sigma_r2_analytic = analytic_kin._sigma_r2(r=r, a=Rs, gamma=gamma, r_ani=r_ani, rho0_r0_gamma=rho0_r0_gamma)
             sigma_r2_num = numeric_kin.sigma_r2(r, kwargs_mass, kwargs_light, kwargs_anisotropy)
             sigma_r_analytic = np.sqrt(sigma_r2_analytic) / 1000
             sigma_r_num = np.sqrt(sigma_r2_num) / 1000

--- a/test/test_GalKin/test_numeric_kinematics.py
+++ b/test/test_GalKin/test_numeric_kinematics.py
@@ -83,6 +83,22 @@ class TestMassProfile(object):
         #plt.show()
         npt.assert_almost_equal(sigma_r_num_array, sigma_r_analytic_array, decimal=-1)
 
+    def test_delete_cache(self):
+        kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
+        kwargs_numerics = {'interpol_grid_num': 500, 'log_integration': True,
+                           'max_integrate': 100}
+
+        kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': 1}
+        kwargs_model = {'mass_profile_list': [],
+                        'light_profile_list': [],
+                        'anisotropy_model': 'const'}
+        numeric_kin = NumericKinematics(kwargs_model, kwargs_cosmo, **kwargs_numerics)
+        numeric_kin._interp_jeans_integral = 1
+        numeric_kin._log_mass_3d = 2
+        numeric_kin.delete_cache()
+        assert hasattr(numeric_kin, '_log_mass_3d') is False
+        assert hasattr(numeric_kin, '_interp_jeans_integral') is False
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_GalKin/test_numeric_kinematics.py
+++ b/test/test_GalKin/test_numeric_kinematics.py
@@ -22,6 +22,15 @@ class TestMassProfile(object):
         mass_3d_exact = massProfile.mass_3d(r, kwargs_profile)
         npt.assert_almost_equal(mass_3d/mass_3d_exact, 1., decimal=3)
 
+    def test_sigma_r2(self):
+        """
+        tests the solution of the Jeans equation for sigma**2(r), where r is the 3d radius.
+        Test is compared to analytic OM solution with power-law and Hernquist light profile
+
+        :return:
+        """
+        pass
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_GalKin/test_velocity_util.py
+++ b/test/test_GalKin/test_velocity_util.py
@@ -36,7 +36,7 @@ class TestVelocityUtil(object):
             r = velocity_util.draw_moffat_r(FWHM, beta)
             r_list.append(r)
         x_array = np.linspace(0, 4 * FWHM, num=100)
-        r_hist, bins = np.histogram(r_list, bins=x_array, normed=True)
+        r_hist, bins = np.histogram(r_list, bins=x_array, density=True)
         alpha = velocity_util.moffat_fwhm_alpha(FWHM, beta)
 
         x_ = x_array[1:] - x_array[1] + x_array[0]

--- a/test/test_LensModel/test_profile_integrals.py
+++ b/test/test_LensModel/test_profile_integrals.py
@@ -58,7 +58,7 @@ class TestNumerics(object):
             mass_2d = lensModel.mass_2d_lens(r, **kwargs)
             alpha_x, alpha_y = lensModel.derivatives(r, 0, **kwargs)
             alpha = np.sqrt(alpha_x**2 + alpha_y**2)
-            npt.assert_almost_equal(alpha, mass_2d/r / np.pi, decimal=5)
+            npt.assert_almost_equal(alpha, mass_2d/ r / np.pi, decimal=5)
 
     def test_PJaffe(self):
         kwargs = {'rho0': 1., 'Ra': 0.2, 'Rs': 2.}


### PR DESCRIPTION
adds a numerical radial jeans equation solution to be used to compute the velocity dispersion at 3D distances instead of directly computing the line-of-sight integrated component. This can be used to assess whether phase-space density functions are finite. 