### PR TITLE
Add support for backup MCMC state and use it as starting point

### DIFF
--- a/lenstronomy/Sampling/sampler.py
+++ b/lenstronomy/Sampling/sampler.py
@@ -120,7 +120,7 @@ class Sampler(object):
         return result, [chi2_list, pos_list, vel_list]
 
     def mcmc_emcee(self, n_walkers, n_run, n_burn, mean_start, sigma_start, mpi=False, progress=False, threadCount=1,
-                   initpos=None):
+                   initpos=None, backup_filename=None, start_from_backup=False):
         """
         Run MCMC with emcee.
         For details, please have a look at the documentation of the emcee packager.
@@ -143,6 +143,11 @@ class Sampler(object):
         :type threadCount: integer
         :param initpos: initial walker position to start sampling (optional)
         :type initpos: numpy array of size num param x num walkser
+        :param backup_filename: name of the HDF5 file where sampling state is saved (through emcee backend engine)
+        :type backup_filename: string
+        :param start_from_backup: if True, start from the state saved in `backup_filename`.
+        Otherwise, create a new backup file with name `backup_filename` (any already existing file is overwritten!).
+        :type start_from_backup: bool
         :return: samples, ln likelihood value of samples
         :rtype: numpy 2d array, numpy 1d array
         """
@@ -150,12 +155,21 @@ class Sampler(object):
         if initpos is None:
             initpos = sampling_util.sample_ball(mean_start, sigma_start, n_walkers, dist='normal')
 
-        time_start = time.time()
-
         pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
 
+        if backup_filename is not None:
+            backend = emcee.backends.HDFBackend(backup_filename, name="lenstronomy_mcmc_emcee")
+            if not start_from_backup:
+                backend.reset(n_walkers, num_param)
+                if pool.is_master():
+                    print("Warning: all samples (including burn-in) are saved in backup file '{}' (i.e. might be used as a future initial state)".format(backup_filename))
+        else:
+            backend = None
+
+        time_start = time.time()
+
         sampler = emcee.EnsembleSampler(n_walkers, num_param, self.chain.logL,
-                                        pool=pool)
+                                        pool=pool, backend=backend)
 
         sampler.run_mcmc(initpos, n_burn + n_run, progress=progress)
         flat_samples = sampler.get_chain(discard=n_burn, thin=1, flat=True)

--- a/lenstronomy/Sampling/sampler.py
+++ b/lenstronomy/Sampling/sampler.py
@@ -162,7 +162,9 @@ class Sampler(object):
             if not start_from_backup:
                 backend.reset(n_walkers, num_param)
                 if pool.is_master():
-                    print("Warning: all samples (including burn-in) are saved in backup file '{}' (i.e. might be used as a future initial state)".format(backup_filename))
+                    print("Warning: backup file '{}' has been reset!".format(backup_filename))
+            if pool.is_master():
+                print("Warning: All samples (including burn-in) will be saved in backup file '{}'.".format(backup_filename))
         else:
             backend = None
 

--- a/lenstronomy/Workflow/fitting_sequence.py
+++ b/lenstronomy/Workflow/fitting_sequence.py
@@ -186,7 +186,7 @@ class FittingSequence(object):
         return kwargs_result
 
     def mcmc(self, n_burn, n_run, walkerRatio, sigma_scale=1, threadCount=1, init_samples=None, re_use_samples=True,
-             sampler_type='EMCEE', progress=True):
+             sampler_type='EMCEE', progress=True, backup_filename=None, start_from_backup=False):
         """
         MCMC routine
 
@@ -226,7 +226,8 @@ class FittingSequence(object):
         if sampler_type is 'EMCEE':
             n_walkers = num_param * walkerRatio
             samples, dist = mcmc_class.mcmc_emcee(n_walkers, n_run, n_burn, mean_start, sigma_start, mpi=self._mpi,
-                                                  threadCount=threadCount, progress=progress, initpos=initpos)
+                                                  threadCount=threadCount, progress=progress, initpos=initpos,
+                                                  backup_filename=backup_filename, start_from_backup=start_from_backup)
             output = [sampler_type, samples, param_list, dist]
         else:
             raise ValueError('sampler_type %s not supported!' % sampler_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pymultinest
 pypolychord
 nestcheck
 corner
+h5py
 #schwimmbad==0.3.0
 -e git://github.com/adrn/schwimmbad.git@master#egg=schwimmbad
 multiprocess>=0.70.8

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -2,6 +2,7 @@ __author__ = 'sibirrer'
 
 import pytest
 import numpy as np
+import os
 import lenstronomy.Util.simulation_util as sim_util
 from lenstronomy.ImSim.image_model import ImageModel
 from lenstronomy.Sampling.likelihood import LikelihoodModule
@@ -104,6 +105,20 @@ class TestSampler(object):
         samples, dist = self.sampler.mcmc_emcee(n_walkers, n_run, n_burn, mean_start, sigma_start, mpi=False)
         assert len(samples) == n_walkers * n_run
         assert len(dist) == len(samples)
+
+        # test of backup file
+        # 1) run a chain specifiying a backup file name
+        backup_filename = 'test_mcmc_emcee.h5'
+        samples_1, dist_1 = self.sampler.mcmc_emcee(n_walkers, n_run, n_burn, mean_start, sigma_start, mpi=False,
+                                                    backup_filename=backup_filename)
+        assert len(samples_1) == n_walkers * n_run
+        # 2) run a chain starting from the backup of previous run
+        samples_2, dist_2 = self.sampler.mcmc_emcee(n_walkers, n_run, n_burn, mean_start, sigma_start, mpi=False,
+                                                    backup_filename=backup_filename, start_from_backup=True)
+        assert len(samples_2) == len(samples_1) + n_walkers * (n_burn + n_run)
+        assert len(dist_2) == len(samples_2)
+        
+        os.remove(backup_filename)  # just remove the backup file created above
 
 
 if __name__ == '__main__':

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -115,7 +115,7 @@ class TestSampler(object):
         # 2) run a chain starting from the backup of previous run
         samples_2, dist_2 = self.sampler.mcmc_emcee(n_walkers, n_run, n_burn, mean_start, sigma_start, mpi=False,
                                                     backup_filename=backup_filename, start_from_backup=True)
-        assert len(samples_2) == len(samples_1) + n_walkers * (n_burn + n_run)
+        assert len(samples_2) == len(samples_1) + n_walkers * n_run
         assert len(dist_2) == len(samples_2)
         
         os.remove(backup_filename)  # just remove the backup file created above


### PR DESCRIPTION
This feature propagates the emcee "backend" feature to the MCMC sampler routine. This allows the user to provide a name of a backup file that keeps track of the MCMC sampling (_including burn-in iterations_), and can be used as initial state of a future MCMC run.

Two new parameters were added to the MCMC fitting step:
- `backup_filename` (defaults to `None`): name of the HDF5 file used to save the chains during sampling.
- `start_from_backup` (defaults to `False`): if `True`, starts from the state saved in the backup file. If `n_burn` is set, this will discard samples from the very beginning of the samples backed up (there was no burn-in applied before saving the previous samples).