### PR TITLE
elliptical power law (EPL), Tessore & Metcalf 2015

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,6 +30,7 @@ Contributors (alphabetic)
 * Ji Won Park `jiwoncpark <https://github.com/jiwoncpark/>`_
 * Thomas Schmidt `Thomas-01 <https://github.com/Thomas-01/>`_
 * Dominique Sluse
+* Nicolas Tessore `ntessore <https://github.com/ntessore/>`_
 * Lyne Van de Vyvere `LyneVdV <https://github.com/LyneVdV/>`_
 * Cyril Welschen
 * Lilan Yang `ylilan <https://github.com/ylilan/>`_

--- a/lenstronomy/LensModel/Profiles/epl.py
+++ b/lenstronomy/LensModel/Profiles/epl.py
@@ -1,0 +1,241 @@
+__author__ = 'ntessore'
+
+import numpy as np
+import lenstronomy.Util.util as util
+import lenstronomy.Util.param_util as param_util
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from scipy.special import hyp2f1
+
+
+class EPL(LensProfileBase):
+    """
+    Elliptical Power Law
+    kappa = (2-t)/2*(b/r)^t
+    """
+    param_names = ['theta_E', 'e1', 'e2', 't', 'center_x', 'center_y']
+    lower_limit_default = {'theta_E': 0, 'e1': -0.5, 'e2': -0.5, 't': 0, 'center_x': -100, 'center_y': -100}
+    upper_limit_default = {'theta_E': 10, 'e1': 0.5, 'e2': -0.5, 't': 2, 'center_x': 100, 'center_y': 100}
+
+    def __init__(self):
+        self.epl_major_axis = EPLMajorAxis()
+        super(EPL, self).__init__()
+
+    def param_conv(self, theta_E, e1, e2, t):
+        if self._static is True:
+            return self._b_static, self._t_static, self._q_static, self._phi_G_static
+        return self._param_conv(theta_E, e1, e2, t)
+
+    def _param_conv(self, theta_E, e1, e2, t):
+        """
+        convert parameters from R = r sqrt(1 − e*cos(2*phi)) to
+        R = sqrt(q^2 x^2 + y^2)
+
+        :param theta_E: Einstein radius
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param t: power law slope
+        :return: critical radius b, slope t, axis ratio q, orientation angle phi_G
+        """
+
+        phi_G, q = param_util.ellipticity2phi_q(e1, e2)
+        theta_E_conv = self._theta_E_q_convert(theta_E, q)
+        b = theta_E_conv * np.sqrt((1 + q**2)/2)
+        return b, t, q, phi_G
+
+    def set_static(self, theta_E, e1, e2, t, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param t: power law slope
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: self variables set
+        """
+        self._static = True
+        self._b_static, self._t_static, self._q_static, self._phi_G_static = self._param_conv(theta_E, e1, e2, t)
+
+    def set_dynamic(self):
+        """
+
+        :return:
+        """
+        self._static = False
+        if hasattr(self, '_b_static'):
+            del self._b_static
+        if hasattr(self, '_t_static'):
+            del self._t_static
+        if hasattr(self, '_phi_G_static'):
+            del self._phi_G_static
+        if hasattr(self, '_q_static'):
+            del self._q_static
+
+    def function(self, x, y, theta_E, e1, e2, t, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param t: power law slope
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: lensing potential
+        """
+        b, t, q, phi_G = self.param_conv(theta_E, e1, e2, t)
+        # shift
+        x_ = x - center_x
+        y_ = y - center_y
+        # rotate
+        x__, y__ = util.rotate(x_, y_, phi_G)
+        # evaluate
+        f_ = self.epl_major_axis.function(x__, y__, b, t, q)
+        # rotate back
+        return f_
+
+    def derivatives(self, x, y, theta_E, e1, e2, t, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param t: power law slope
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: alpha_x, alpha_y
+        """
+        b, t, q, phi_G = self.param_conv(theta_E, e1, e2, t)
+        # shift
+        x_ = x - center_x
+        y_ = y - center_y
+        # rotate
+        x__, y__ = util.rotate(x_, y_, phi_G)
+        # evaluate
+        f__x, f__y = self.epl_major_axis.derivatives(x__, y__, b, t, q)
+        # rotate back
+        f_x, f_y = util.rotate(f__x, f__y, -phi_G)
+        return f_x, f_y
+
+    def hessian(self, x, y, theta_E, e1, e2, t, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param t: power law slope
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: f_xx, f_yy, f_xy
+        """
+        b, t, q, phi_G = self.param_conv(theta_E, e1, e2, t)
+        # shift
+        x_ = x - center_x
+        y_ = y - center_y
+        # rotate
+        x__, y__ = util.rotate(x_, y_, phi_G)
+        # evaluate
+        f__xx, f__yy, f__xy = self.epl_major_axis.hessian(x__, y__, b, t, q)
+        # rotate back
+        kappa = 1./2 * (f__xx + f__yy)
+        gamma1__ = 1./2 * (f__xx - f__yy)
+        gamma2__ = f__xy
+        gamma1 = np.cos(2 * phi_G) * gamma1__ - np.sin(2 * phi_G) * gamma2__
+        gamma2 = +np.sin(2 * phi_G) * gamma1__ + np.cos(2 * phi_G) * gamma2__
+        f_xx = kappa + gamma1
+        f_yy = kappa - gamma1
+        f_xy = gamma2
+        return f_xx, f_yy, f_xy
+
+    def _theta_E_q_convert(self, theta_E, q):
+        """
+        converts a spherical averaged Einstein radius to an elliptical (major axis) Einstein radius.
+        This then follows the convention of the SPEMD profile in lenstronomy.
+        (theta_E / theta_E_gravlens) = sqrt[ (1+q^2) / (2 q) ]
+
+        :param theta_E: Einstein radius in lenstronomy conventions
+        :param q: axis ratio minor/major
+        :return: theta_E in convention of kappa=  b *(q2(s2 + x2) + y2􏰉)−1/2
+        """
+        theta_E_new = theta_E / (np.sqrt((1.+q**2) / (2. * q))) #/ (1+(1-q)/2.)
+        return theta_E_new
+
+
+class EPLMajorAxis(LensProfileBase):
+    """
+    This class contains the function and the derivatives of the
+    elliptical power law.
+
+    kappa = (2-t)/2 * [b/sqrt(q^2 x^2 + y^2)]^t
+
+    Tessore & Metcalf (2015), https://arxiv.org/abs/1507.01819
+    """
+    param_names = ['b', 't', 'q', 'center_x', 'center_y']
+
+    def __init__(self):
+        super(EPLMajorAxis, self).__init__()
+
+    def function(self, x, y, b, t, q):
+        """
+        returns the lensing potential
+        """
+        # deflection from method
+        alpha_x, alpha_y = self.derivatives(x, y, b, t, q)
+
+        # deflection potential, eq. (15)
+        psi = (x*alpha_x + y*alpha_y)/(2 - t)
+
+        return psi
+
+    def derivatives(self, x, y, b, t, q):
+        """
+        returns the deflection
+        """
+        # elliptical radius, eq. (5)
+        Z = np.empty(np.shape(x), dtype=complex)
+        Z.real = q*x
+        Z.imag = y
+        R = np.abs(Z)
+
+        # angular dependency with extra factor of R, eq. (23)
+        R_omega = Z*hyp2f1(1, t/2, 2-t/2, -(1-q)/(1+q)*(Z/Z.conj()))
+
+        # deflection, eq. (22)
+        alpha = 2/(1+q)*(b/R)**t*R_omega
+
+        # return real and imaginary part
+        return alpha.real, alpha.imag
+
+    def hessian(self, x, y, b, t, q):
+        """
+        returns the Hessian matrix of the lensing potential
+        """
+        R = np.hypot(q*x, y)
+        r = np.hypot(x, y)
+
+        cos, sin = x/r, y/r
+        cos2, sin2 = cos*cos*2 - 1, sin*cos*2
+
+        # convergence, eq. (2)
+        kappa = (2 - t)/2*(b/R)**t
+
+        # deflection via method
+        alpha_x, alpha_y = self.derivatives(x, y, b, t, q)
+
+        # shear, eq. (17), corrected version from arXiv/corrigendum
+        gamma_1 = (1-t)*(alpha_x*cos - alpha_y*sin)/r - kappa*cos2
+        gamma_2 = (1-t)*(alpha_y*cos + alpha_x*sin)/r - kappa*sin2
+
+        # second derivatives from convergence and shear
+        f_xx = kappa + gamma_1
+        f_yy = kappa - gamma_1
+        f_xy = gamma_2
+
+        return f_xx, f_yy, f_xy

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -110,6 +110,12 @@ class ProfileListBase(object):
         elif lens_type == 'SPEMD':
             from lenstronomy.LensModel.Profiles.spemd import SPEMD
             return SPEMD()
+        elif lens_type == 'EPL':
+            from lenstronomy.LensModel.Profiles.epl import EPL
+            return EPL()
+        elif lens_type == 'EPL_SIMPLE':
+            from lenstronomy.LensModel.Profiles.epl import EPLMajorAxis
+            return EPLMajorAxis()
         elif lens_type == 'NFW':
             from lenstronomy.LensModel.Profiles.nfw import NFW
             return NFW()

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -113,9 +113,6 @@ class ProfileListBase(object):
         elif lens_type == 'EPL':
             from lenstronomy.LensModel.Profiles.epl import EPL
             return EPL()
-        elif lens_type == 'EPL_SIMPLE':
-            from lenstronomy.LensModel.Profiles.epl import EPLMajorAxis
-            return EPLMajorAxis()
         elif lens_type == 'NFW':
             from lenstronomy.LensModel.Profiles.nfw import NFW
             return NFW()

--- a/test/test_LensModel/test_Profiles/test_epl.py
+++ b/test/test_LensModel/test_Profiles/test_epl.py
@@ -1,0 +1,71 @@
+__author__ = 'sibirrer'
+
+
+import numpy as np
+import pytest
+import numpy.testing as npt
+import lenstronomy.Util.param_util as param_util
+
+
+class TestEPL(object):
+    """
+    tests the Gaussian methods
+    """
+    def setup(self):
+        from lenstronomy.LensModel.Profiles.epl import EPL
+        self.EPL = EPL()
+        from lenstronomy.LensModel.Profiles.nie import NIE
+        self.NIE = NIE()
+
+    def test_function(self):
+        phi_E = 1.
+        t = 1.
+        q = 0.999
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        x = np.array([1., 2])
+        y = np.array([2, 0])
+        values = self.EPL.function(x, y, phi_E, e1, e2, t)
+        values_nie = self.NIE.function(x, y, phi_E, e1, e2, 0.)
+        delta_f = values[0] - values[1]
+        delta_f_nie = values_nie[0] - values_nie[1]
+        npt.assert_almost_equal(delta_f, delta_f_nie, decimal=5)
+
+    def test_derivatives(self):
+        x = np.array([1])
+        y = np.array([2])
+        phi_E = 1.
+        t = 1.
+        q = 1.
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        f_x, f_y = self.EPL.derivatives(x, y, phi_E, e1, e2, t)
+        f_x_nie, f_y_nie = self.NIE.derivatives(x, y, phi_E, e1, e2, 0.)
+        npt.assert_almost_equal(f_x, f_x_nie, decimal=4)
+        npt.assert_almost_equal(f_y, f_y_nie, decimal=4)
+
+        q = 0.7
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        f_x, f_y = self.EPL.derivatives(x, y, phi_E, e1, e2, t)
+        f_x_nie, f_y_nie = self.NIE.derivatives(x, y, phi_E, e1, e2, 0.)
+        npt.assert_almost_equal(f_x, f_x_nie, decimal=4)
+        npt.assert_almost_equal(f_y, f_y_nie, decimal=4)
+
+    def test_hessian(self):
+        x = np.array([1.])
+        y = np.array([2.])
+        phi_E = 1.
+        t = 1.
+        q = 0.9
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        f_xx, f_yy,f_xy = self.EPL.hessian(x, y, phi_E, e1, e2, t)
+        f_xx_nie, f_yy_nie, f_xy_nie = self.NIE.hessian(x, y, phi_E, e1, e2, 0.)
+        npt.assert_almost_equal(f_xx, f_xx_nie, decimal=4)
+        npt.assert_almost_equal(f_yy, f_yy_nie, decimal=4)
+        npt.assert_almost_equal(f_xy, f_xy_nie, decimal=4)
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/test/test_LensModel/test_Profiles/test_epl.py
+++ b/test/test_LensModel/test_Profiles/test_epl.py
@@ -31,6 +31,26 @@ class TestEPL(object):
         delta_f_nie = values_nie[0] - values_nie[1]
         npt.assert_almost_equal(delta_f, delta_f_nie, decimal=5)
 
+        q = 0.8
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        x = np.array([1., 2])
+        y = np.array([2, 0])
+        values = self.EPL.function(x, y, phi_E, e1, e2, t)
+        values_nie = self.NIE.function(x, y, phi_E, e1, e2, 0.)
+        delta_f = values[0] - values[1]
+        delta_f_nie = values_nie[0] - values_nie[1]
+        npt.assert_almost_equal(delta_f, delta_f_nie, decimal=5)
+
+        q = 0.4
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        x = np.array([1., 2])
+        y = np.array([2, 0])
+        values = self.EPL.function(x, y, phi_E, e1, e2, t)
+        values_nie = self.NIE.function(x, y, phi_E, e1, e2, 0.)
+        delta_f = values[0] - values[1]
+        delta_f_nie = values_nie[0] - values_nie[1]
+        npt.assert_almost_equal(delta_f, delta_f_nie, decimal=5)
+
     def test_derivatives(self):
         x = np.array([1])
         y = np.array([2])
@@ -65,6 +85,20 @@ class TestEPL(object):
         npt.assert_almost_equal(f_xx, f_xx_nie, decimal=4)
         npt.assert_almost_equal(f_yy, f_yy_nie, decimal=4)
         npt.assert_almost_equal(f_xy, f_xy_nie, decimal=4)
+
+    def test_static(self):
+        x, y = 1., 1.
+        phi_G, q = 0.3, 0.8
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        kwargs_lens = {'theta_E': 1., 't': 1.5, 'e1': e1, 'e2': e2}
+        f_ = self.EPL.function(x, y, **kwargs_lens)
+        self.EPL.set_static(**kwargs_lens)
+        f_static = self.EPL.function(x, y, **kwargs_lens)
+        npt.assert_almost_equal(f_, f_static, decimal=8)
+        self.EPL.set_dynamic()
+        kwargs_lens = {'theta_E': 2., 't': 0.5, 'e1': e1, 'e2': e2}
+        f_dyn = self.EPL.function(x, y, **kwargs_lens)
+        assert f_dyn != f_static
 
 
 if __name__ == '__main__':

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -234,6 +234,11 @@ class TestNumericsProfile(object):
         lens_model = ['NIE_SIMPLE']
         self.assert_differentials(lens_model, kwargs)
 
+    def test_EPL(self):
+        kwargs = {'theta_E': 2., 'e1': 0.1, 'e2': 0., 't': 1.23}
+        lens_model = ['EPL']
+        self.assert_differentials(lens_model, kwargs)
+
     def test_coreBurk(self):
         kwargs={'Rs':2, 'alpha_Rs': 1, 'r_core':0.4}
         lens_model = ['coreBURKERT']


### PR DESCRIPTION
Implements the (singular) elliptical power law (EPL) profile in the form given by [Tessore & Metcalf (2015)](https://arxiv.org/pdf/1507.01819.pdf).

The critical calculation is outsourced to `scipy.special.hyp2f1`. This could be sped up quite significantly using the technique from Section 4 of the paper, in particular if array operations are used.

I have not really looked into the other power law models, so you might want to align the parametrisation before considering merging this. Our power law exponent `t` is the exponent of the 2D density, and differs by unity from models that parametrise the 3D exponent `gamma`.