### PR TITLE
Penalty in TD likelihood for predicted images inconsistent with observations 

### DIFF
--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -43,6 +43,7 @@ class PointSource(object):
         self._fixed_magnification_list = fixed_magnification_list
         if additional_images_list is None:
             additional_images_list = [False] * len(point_source_type_list)
+        self.additional_images_list = additional_images_list
         for i, model in enumerate(point_source_type_list):
             if model == 'UNLENSED':
                 from lenstronomy.PointSource.point_source_types import Unlensed

--- a/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
@@ -65,6 +65,21 @@ class TestImageLikelihood(object):
         logL = td_likelihood.logL(kwargs_lens=kwargs_lens, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
         npt.assert_almost_equal(logL, -0.5, decimal=8)
 
+        # test when using additional_images_list
+        additional_images_list = [True]
+        pointSource = PointSource(point_source_type_list=point_source_list,
+                                  additional_images_list=additional_images_list,
+                                  lensModel=lensModel)
+        td_likelihood = TimeDelayLikelihood(time_delays_measured, time_delays_uncertainties, lens_model_class=lensModel, point_source_class=pointSource)
+        kwargs_cosmo = {'D_dt': lensCosmo.ddt}
+        logL = td_likelihood.logL(kwargs_lens=kwargs_lens, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
+        npt.assert_almost_equal(logL, 0, decimal=8)
+        # with plain wrong mass model, the number of predicted images should not match number of measured delays
+        # and a likelihood penalty (-1e15) should be returned
+        kwargs_lens_wrong = [{'theta_E': 1, 'e1': 0, 'e2': 0, 'gamma': 2, 'center_x': 1, 'center_y': 0},
+                             {'gamma1': 0.05, 'gamma2': -0.01}]
+        logL = td_likelihood.logL(kwargs_lens=kwargs_lens_wrong, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
+        npt.assert_almost_equal(logL, -1e15, decimal=8)
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
When using the point source option `additional_images_list` for allowing the model to predict more images than explicitly modelled, while sampling `D_dt` in the likelihood, I got an issue when comparing model and measured time delays. For instance, the PSO can initially sample a wrong lens model, that will predict a smaller number of delays, inconsistently with measured delays.

This PR proposes a way to solve it: when the "additional image" option is used, and number of predicted delays is smaller than number of measured delays, a penalty (-1e15) is added to the likelihood.