### PR TITLE
Point source ordering

### DIFF
--- a/lenstronomy/Analysis/td_cosmography.py
+++ b/lenstronomy/Analysis/td_cosmography.py
@@ -56,6 +56,8 @@ class TDCosmography(KinematicsAPI):
     def time_delays(self, kwargs_lens, kwargs_ps, kappa_ext=0, original_ps_position=False):
         """
         predicts the time delays of the image positions given the fiducial cosmology
+        The ordering of the time delays are in the same order as provided in the function call
+        PointSource.image_position(kwargs_ps, kwargs_lens, original_position=original_ps_position)
 
         :param kwargs_lens: lens model parameters
         :param kwargs_ps: point source parameters
@@ -71,6 +73,9 @@ class TDCosmography(KinematicsAPI):
 
     def fermat_potential(self, kwargs_lens, kwargs_ps, original_ps_position=False):
         """
+        Fermat potential of all the image positions in the first point source list entry
+        The ordering of the Fermat potential are in the same order as provided in the function call
+        PointSource.image_position(kwargs_ps, kwargs_lens, original_position=original_ps_position)
 
         :param kwargs_lens: lens model keyword argument list
         :param kwargs_ps: point source keyword argument list

--- a/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
@@ -6,14 +6,21 @@ class TimeDelayLikelihood(object):
     """
     class to compute the likelihood of a model given a measurement of time delays
     """
-    def __init__(self, time_delays_measured, time_delays_uncertainties, lens_model_class, point_source_class):
+    def __init__(self, time_delays_measured, time_delays_uncertainties, lens_model_class, point_source_class,
+                 ra_td_position_proxy=None, dec_td_position_proxy=None):
         """
 
         :param time_delays_measured: relative time delays (in days) in respect to the first image of the point source
         :param time_delays_uncertainties: time-delay uncertainties in same order as time_delay_measured
         :param lens_model_class: instance of the LensModel() class
         :param point_source_class: instance of the PointSource() class, note: the first point source type is the one the
-        time delays are imposed on
+         time delays are imposed on
+        :param ra_td_position_proxy: relative RA coordinates of proxy positions of the time delays measured to match as
+         good as possible the predicted and measured time delays (optional, if not set, uses the PointSource() module
+         ordering to compare with the measurements
+        :param dec_td_position_proxy: relative DEC coordinates of proxy positions of the time delays measured to match as
+         good as possible the predicted and measured time delays (optional, if not set, uses the PointSource() module
+         ordering to compare with the measurements
         """
 
         if time_delays_measured is None:
@@ -24,6 +31,7 @@ class TimeDelayLikelihood(object):
         self._delays_errors = np.array(time_delays_uncertainties)
         self._lensModel = lens_model_class
         self._pointSource = point_source_class
+        self._ra_td_position_proxy, self._dec_td_position_proxy = ra_td_position_proxy, dec_td_position_proxy
 
     def logL(self, kwargs_lens, kwargs_ps, kwargs_cosmo):
         """
@@ -33,9 +41,20 @@ class TimeDelayLikelihood(object):
         :param kwargs_cosmo: cosmology and other kwargs
         :return: log likelihood of the model given the time delay data
         """
-        x_pos, y_pos = self._pointSource.image_position(kwargs_ps=kwargs_ps, kwargs_lens=kwargs_lens, original_position=True)
+        x_pos, y_pos = self._pointSource.image_position(kwargs_ps=kwargs_ps, kwargs_lens=kwargs_lens,
+                                                        original_position=True)
         x_pos, y_pos = x_pos[0], y_pos[0]
-        delay_arcsec = self._lensModel.fermat_potential(x_pos, y_pos, kwargs_lens)
+        print(len(self._delays_measured), len(y_pos), 'test')
+        if len(self._delays_measured) > (len(y_pos) - 1):
+            return -np.inf
+        if self._ra_td_position_proxy is not None and self._dec_td_position_proxy is not None:
+            ra_pos_ordered, dec_pos_ordered = order_image_positions_to_proxy(x_pos, y_pos,
+                                                                         ra_proxy=self._ra_td_position_proxy,
+                                                                         dec_proxy=self._dec_td_position_proxy)
+        else:
+            ra_pos_ordered, dec_pos_ordered = x_pos, y_pos
+        print(ra_pos_ordered, x_pos, 'test')
+        delay_arcsec = self._lensModel.fermat_potential(ra_pos_ordered, dec_pos_ordered, kwargs_lens)
         D_dt_model = kwargs_cosmo['D_dt']
         delay_days = const.delay_arcsec2days(delay_arcsec, D_dt_model)
         logL = self._logL_delays(delay_days, self._delays_measured, self._delays_errors)
@@ -61,3 +80,30 @@ class TimeDelayLikelihood(object):
         :return: number of time delay measurements
         """
         return len(self._delays_measured)
+
+
+def order_image_positions_to_proxy(ra_image, dec_image, ra_proxy, dec_proxy):
+        """
+        orders the image positions according to the specified nearest positions for which the time delays are specified
+        This routine is only employed if the 'ra_td_position_proxy' and 'dec_td_position_proxy' are specified
+
+        :param ra_image: image positions of time-variable source (not necessary ordered) (numpy array)
+        :param dec_image: image positions of time-variable source (not necessary ordered) (numpy array)
+        :param ra_proxy: proxy image positions to be matched in sequence (numpy array)
+        :param dec_proxy: proxy image positions to be matched in sequence (numpy array)
+        :return: ordered list or ra_image, dec_image corresponding to closest vicinity to proxy positions of the measurement
+        """
+        ra_image_sort, dec_image_sort = np.empty_like(ra_image), np.empty_like(ra_image)
+        ra_image_, dec_image_ = ra_image, dec_image
+        if len(ra_image) < len(ra_proxy):
+            raise ValueError('length of image positions %s needs to be larger or equal the length of the position '
+                             'proxies %s.' % (len(ra_image), len(ra_proxy)))
+        for i in range(len(ra_proxy)):
+            dist = (ra_image_ - ra_proxy[i])**2 + (dec_image_ - dec_proxy[i])**2
+            index_sorted = np.argsort(dist)
+            ra_image_ = ra_image_[index_sorted]
+            dec_image_ = dec_image_[index_sorted]
+            ra_image_sort[i] = ra_image_[0]
+            dec_image_sort[i] = dec_image_[0]
+            ra_image_, dec_image_ = ra_image_[1:], dec_image_[1:]
+        return ra_image_sort, dec_image_sort

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -12,13 +12,9 @@ import numpy as np
 
 class LikelihoodModule(object):
     """
-    this class contains the routines to run a MCMC process
-    the key components are:
-    - imSim_class: an instance of a class that simulates one (or more) images and returns the likelihood, such as
-    ImageModel(), Multiband(), MultiExposure()
-    - param_class: instance of a Param() class that can cast the sorted list of parameters that are sampled into the conventions of the imSim_class
+    this class contains the routines to run a posterior inference for different combinations of data sets and
+    customizable priors.
 
-    Additional arguments are supported for adding a time-delay likelihood etc (see __init__ definition)
     """
     def __init__(self, kwargs_data_joint, kwargs_model, param_class, image_likelihood=True, check_bounds=True,
                  check_matched_source_position=False, astrometric_likelihood=False, image_position_likelihood=False,
@@ -26,6 +22,7 @@ class LikelihoodModule(object):
                  source_position_tolerance=0.001, source_position_sigma=0.001, force_no_add_image=False,
                  source_marg=False, linear_prior=None, restrict_image_number=False,
                  max_num_images=None, bands_compute=None, time_delay_likelihood=False,
+                 ra_td_position_proxy=None, dec_td_position_proxy=None,
                  force_minimum_source_surface_brightness=False, flux_min=0, image_likelihood_mask_list=None,
                  flux_ratio_likelihood=False, kwargs_flux_compute={}, prior_lens=[], prior_source=[],
                  prior_extinction=[], prior_lens_light=[], prior_ps=[], prior_special=[], prior_lens_kde=[],
@@ -64,6 +61,12 @@ class LikelihoodModule(object):
         :param max_num_images: int, see restrict_image_number
         :param bands_compute: list of bools with same length as data objects, indicates which "band" to include in the fitting
         :param time_delay_likelihood: bool, if True computes the time-delay likelihood of the FIRST point source
+        :param ra_td_position_proxy: relative RA coordinates of proxy positions of the time delays measured to match as
+         good as possible the predicted and measured time delays (optional, if not set, uses the PointSource() module
+         ordering to compare with the measurements
+        :param dec_td_position_proxy: relative DEC coordinates of proxy positions of the time delays measured to match as
+         good as possible the predicted and measured time delays (optional, if not set, uses the PointSource() module
+         ordering to compare with the measurements
         :param force_minimum_source_surface_brightness: bool, if True, evaluates the source surface brightness on a grid
         and evaluates if all positions have positive flux
         :param kwargs_flux_compute: keyword arguments of how to compute the image position fluxes (see FluxRatioLikeliood)
@@ -89,7 +92,9 @@ class LikelihoodModule(object):
         self._time_delay_likelihood = time_delay_likelihood
         if self._time_delay_likelihood is True:
             self.time_delay_likelihood = TimeDelayLikelihood(time_delays_measured, time_delays_uncertainties,
-                                                             lens_model_class, point_source_class)
+                                                             lens_model_class, point_source_class,
+                                                             ra_td_position_proxy=ra_td_position_proxy,
+                                                             dec_td_position_proxy=dec_td_position_proxy)
 
         self._image_likelihood = image_likelihood
         if self._image_likelihood is True:

--- a/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
@@ -1,4 +1,5 @@
 from lenstronomy.Sampling.Likelihoods.time_delay_likelihood import TimeDelayLikelihood
+from lenstronomy.Sampling.Likelihoods.time_delay_likelihood import order_image_positions_to_proxy
 from lenstronomy.LensModel.lens_model import LensModel
 from lenstronomy.PointSource.point_source import PointSource
 from lenstronomy.LensModel.Solver.lens_equation_solver import LensEquationSolver
@@ -8,6 +9,7 @@ import numpy.testing as npt
 import numpy as np
 import pytest
 import copy
+import unittest
 
 
 class TestImageLikelihood(object):
@@ -64,6 +66,20 @@ class TestImageLikelihood(object):
         kwargs_cosmo = {'D_dt': lensCosmo.ddt}
         logL = td_likelihood.logL(kwargs_lens=kwargs_lens, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
         npt.assert_almost_equal(logL, -0.5, decimal=8)
+
+
+class TestImageOrdering(unittest.TestCase):
+
+    def test_order_image_positions_to_proxy(self):
+        ra_image, dec_image = np.array([1, 3, 2]), np.array([2, 1, 0])
+        ra_proxy, dec_proxy = np.array([1, 2, 3]), np.array([2, 0, 1])
+
+        ra_sort, dec_sort = order_image_positions_to_proxy(ra_image, dec_image, ra_proxy=ra_proxy, dec_proxy=dec_proxy)
+        npt.assert_almost_equal(ra_sort, ra_proxy, decimal=6)
+        npt.assert_almost_equal(dec_sort, dec_proxy, decimal=6)
+
+        with self.assertRaises(ValueError):
+            order_image_positions_to_proxy(ra_image[1:], dec_image[1:], ra_proxy=ra_proxy, dec_proxy=dec_proxy)
 
 
 if __name__ == '__main__':

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -39,7 +39,6 @@ class TestLikelihoodModule(object):
         data_class = ImageData(**kwargs_band)
         kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix}
         psf_class = PSF(**kwargs_psf)
-        print(np.shape(psf_class.kernel_point_source), 'test kernel shape -')
         kwargs_spemd = {'theta_E': 1., 'gamma': 1.95, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}
 
         self.kwargs_lens = [kwargs_spemd]
@@ -97,10 +96,10 @@ class TestLikelihoodModule(object):
                              'image_position_likelihood': True
                              }
         self.kwargs_data = {'multi_band_list': [[kwargs_band, kwargs_psf, kwargs_numerics]], 'multi_band_type': 'single-band',
-                            'time_delays_measured': np.ones(4),
-                            'time_delays_uncertainties': np.ones(4),
-                            'flux_ratios': np.ones(4),
-                            'flux_ratio_errors': np.ones(4),
+                            'time_delays_measured': np.ones(len(ra_pos) - 1),
+                            'time_delays_uncertainties': np.ones(len(ra_pos) - 1),
+                            'flux_ratios': np.ones(len(ra_pos) - 1),
+                            'flux_ratio_errors': np.ones(len(ra_pos) - 1),
                             'ra_image_list': ra_pos,
                             'dec_image_list': dec_pos
                             }
@@ -126,26 +125,7 @@ class TestLikelihoodModule(object):
                                             kwargs_lens_light=self.kwargs_lens_light, kwargs_ps=self.kwargs_ps, kwargs_special=self.kwargs_cosmo)
 
         logL = likelihood.logL(args, verbose=True)
-        npt.assert_almost_equal(logL, -3080.29, decimal=-1)
-
-    #def test_solver(self):
-        # make simulation with point source positions in image plane
-    #    x_pos, y_pos = self.imageModel.PointSource.image_position(self.kwargs_ps, self.kwargs_lens)
-    #    kwargs_ps = [{'ra_image': x_pos[0], 'dec_image': y_pos[0]}]
-
-    #    kwargs_likelihood = {
-    #                         'source_marg': True,
-    #                         'astrometric_likelihood': True,
-    #                         'position_uncertainty': 0.004,
-    #                         'check_solver': True,
-    #                         'solver_tolerance': 0.001,
-    #                         'check_positive_flux': True,
-    #                         'solver': True
-    #                         }
-
-        #imageModel = ImageModel(self.data_class, self.psf_class, self.lens_model_class, self.source_model_class,
-        #                        self.lens_light_model_class,
-        #                        point_source_class, kwargs_numerics=kwargs_numerics)
+        npt.assert_almost_equal(logL, -1277.11, decimal=-1)
 
     def test_force_positive_source_surface_brightness(self):
         kwargs_likelihood = {'force_minimum_source_surface_brightness': True}


### PR DESCRIPTION
This PR is related to issue #184 and PR #185 . It adds the feature of pre-specified image position proxies to guarantee the time delay differences are evaluated in the model between the correct images. This feature is relevant when the modeling of the time-variable point source is performed in the source plane and the lens equation is solved for.