### PR TITLE
Increase LSST coadd_years support

### DIFF
--- a/lenstronomy/SimulationAPI/ObservationConfig/LSST.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/LSST.py
@@ -68,7 +68,7 @@ class LSST(object):
 
         :param band: string, 'u', 'g', 'r', 'i', 'z' or 'y' supported. Determines obs dictionary.
         :param psf_type: string, type of PSF ('GAUSSIAN' supported).
-        :param coadd_years: int, number of years corresponding to num_exposures in obs dict. Currently supported: 10.
+        :param coadd_years: int, number of years corresponding to num_exposures in obs dict. Currently supported: 1-10.
         """
         if band.isalpha():
             band = band.lower()
@@ -90,9 +90,11 @@ class LSST(object):
         if psf_type != 'GAUSSIAN':
             raise ValueError("psf_type %s not supported!" % psf_type)
 
-        if coadd_years != 10:
-            raise ValueError(" %s coadd_years not supported! "
-                             "You may manually adjust num_exposures in obs dict if required." % coadd_years)
+        if coadd_years > 10 or coadd_years < 1:
+            raise ValueError(" %s coadd_years not supported! Choose an integer between 1 and 10." % coadd_years)
+        elif coadd_years != 10:
+            self.obs['num_exposures'] = coadd_years*self.obs['num_exposures']//10
+
 
         self.camera = {'read_noise': 10,  # will be <10
                        'pixel_scale': 0.2,

--- a/test/test_SimulationAPI/test_ObservationConfig/test_LSST.py
+++ b/test/test_SimulationAPI/test_ObservationConfig/test_LSST.py
@@ -57,6 +57,8 @@ class TestLSST(unittest.TestCase):
         with self.assertRaises(ValueError):
             bad_psf = LSST(psf_type='blah')
 
+        single_year = LSST(coadd_years=1)
+        self.assertEqual(single_year.obs["num_exposures"], 20)
         with self.assertRaises(ValueError):
             bad_coadd_years = LSST(coadd_years=100)
 


### PR DESCRIPTION
Minor change expanding support for coadd_years in LSST configs from 10 to 1-10