### PR TITLE
Redshift sampling

### DIFF
--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -13,7 +13,8 @@ class LensModel(object):
     """
 
     def __init__(self, lens_model_list, z_lens=None, z_source=None, lens_redshift_list=None, cosmo=None,
-                 multi_plane=False, numerical_alpha_class=None, observed_convention_index=None, z_source_convention=None):
+                 multi_plane=False, numerical_alpha_class=None, observed_convention_index=None,
+                 z_source_convention=None):
         """
 
         :param lens_model_list: list of strings with lens model names
@@ -54,7 +55,8 @@ class LensModel(object):
                                          z_source_convention=z_source_convention)
         else:
             self.lens_model = SinglePlane(lens_model_list, numerical_alpha_class=numerical_alpha_class,
-                                          lens_redshift_list=lens_redshift_list, z_source_convention=z_source_convention)
+                                          lens_redshift_list=lens_redshift_list,
+                                          z_source_convention=z_source_convention)
         if z_lens is not None and z_source is not None:
             self._lensCosmo = LensCosmo(z_lens, z_source, cosmo=cosmo)
 
@@ -272,6 +274,13 @@ class LensModel(object):
         f_yyy = (f_yy_dy - f_yy_dy_) / diff / 2
         return f_xxx, f_xxy, f_xyy, f_yyy
 
+    def updated_lens_redshift(self, lens_redshift_list):
+        """
+
+        :param lens_redshift_list:
+        :return:
+        """
+
     def set_static(self, kwargs):
         """
         set this instance to a static lens model. This can improve the speed in evaluating lensing quantities at
@@ -318,8 +327,6 @@ class LensModel(object):
         :param y: y-coordinate
         :return: f_xx, f_xy, f_yx, f_yy
         """
-        #alpha_ra, alpha_dec = self.alpha(x, y, kwargs, k=k)
-
         alpha_ra_dx, alpha_dec_dx = self.alpha(x + diff, y, kwargs, k=k)
         alpha_ra_dy, alpha_dec_dy = self.alpha(x, y + diff, kwargs, k=k)
 

--- a/lenstronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/image_likelihood.py
@@ -7,14 +7,14 @@ class ImageLikelihood(object):
     manages imaging data likelihoods
     """
 
-    def __init__(self, multi_band_list, multi_band_type, kwargs_model, bands_compute=None, likelihood_mask_list=None,
+    def __init__(self, multi_band_list, multi_band_type, kwargs_model, bands_compute=None, image_likelihood_mask_list=None,
                  source_marg=False, linear_prior=None, check_positive_flux=False):
         """
 
         :param imSim_class: instance of a class that simulates one (or more) images and returns the likelihood, such as
         ImageModel(), Multiband(), MultiExposure()
         :param bands_compute: list of bools with same length as data objects, indicates which "band" to include in the fitting
-        :param likelihood_mask_list: list of boolean 2d arrays of size of images marking the pixels to be evaluated in the likelihood
+        :param image_likelihood_mask_list: list of boolean 2d arrays of size of images marking the pixels to be evaluated in the likelihood
         :param source_marg: marginalization addition on the imaging likelihood based on the covariance of the inferred
         linear coefficients
         :param linear_prior: float or list of floats (when multi-linear setting is chosen) indicating the range of
@@ -26,7 +26,7 @@ class ImageLikelihood(object):
         """
 
         self.imSim = class_creator.create_im_sim(multi_band_list, multi_band_type, kwargs_model,
-                                                 bands_compute=bands_compute, likelihood_mask_list=likelihood_mask_list)
+                                                 bands_compute=bands_compute, likelihood_mask_list=image_likelihood_mask_list)
         self._model_type = self.imSim.type
         self._source_marg = source_marg
         self._linear_prior = linear_prior

--- a/lenstronomy/Sampling/Likelihoods/position_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/position_likelihood.py
@@ -107,7 +107,8 @@ class PositionLikelihood(object):
                     return True
         return False
 
-    def astrometric_likelihood(self, kwargs_ps, kwargs_special, sigma):
+    @staticmethod
+    def astrometric_likelihood(kwargs_ps, kwargs_special, sigma):
         """
         evaluates the astrometric uncertainty of the model plotted point sources (only available for 'LENSED_POSITION'
         point source model) and predicted image position by the lens model including an astrometric correction term.

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -67,16 +67,14 @@ class LikelihoodModule(object):
         :param custom_logL_addition: a definition taking as arguments (kwargs_lens, kwargs_source, kwargs_lens_light,
          kwargs_ps, kwargs_special, kwargs_extinction) and returns a logL (punishing) value.
         """
-        multi_band_list, image_type, time_delays_measured, time_delays_uncertainties, flux_ratios, flux_ratio_errors, ra_image_list, dec_image_list = self._unpack_data(**kwargs_data_joint)
+        multi_band_list, multi_band_type, time_delays_measured, time_delays_uncertainties, flux_ratios, flux_ratio_errors, ra_image_list, dec_image_list = self._unpack_data(**kwargs_data_joint)
         if len(multi_band_list) == 0:
             image_likelihood = False
 
         self.param = param_class
         self._lower_limit, self._upper_limit = self.param.param_limits()
-        lens_model_class, source_model_class, lens_light_model_class, point_source_class, extinction_class = class_creator.create_class_instances(**kwargs_model)
-        self.PointSource = point_source_class
-
-        self._prior_likelihood = PriorLikelihood(prior_lens, prior_source, prior_lens_light, prior_ps, prior_special, prior_extinction,
+        self._prior_likelihood = PriorLikelihood(prior_lens, prior_source, prior_lens_light, prior_ps, prior_special,
+                                                 prior_extinction,
                                                  prior_lens_kde, prior_source_kde, prior_lens_light_kde, prior_ps_kde,
                                                  prior_special_kde, prior_extinction_kde,
                                                  prior_lens_lognormal, prior_source_lognormal,
@@ -84,56 +82,60 @@ class LikelihoodModule(object):
                                                  prior_special_lognormal, prior_extinction_lognormal,
                                                  )
         self._time_delay_likelihood = time_delay_likelihood
-        if self._time_delay_likelihood is True:
-            self.time_delay_likelihood = TimeDelayLikelihood(time_delays_measured, time_delays_uncertainties,
-                                                             lens_model_class, point_source_class)
-
         self._image_likelihood = image_likelihood
-        if self._image_likelihood is True:
-            self.image_likelihood = ImageLikelihood(multi_band_list, image_type, kwargs_model, bands_compute=bands_compute,
-                                                    likelihood_mask_list=image_likelihood_mask_list,
-                                                    source_marg=source_marg, linear_prior=linear_prior,
-                                                    check_positive_flux=check_positive_flux)
-        self._position_likelihood = PositionLikelihood(point_source_class, astrometric_likelihood=astrometric_likelihood,
-                                                       image_position_likelihood=image_position_likelihood,
-                                                       source_position_likelihood=source_position_likelihood,
-                                                       ra_image_list=ra_image_list, dec_image_list=dec_image_list,
-                                                       image_position_uncertainty=image_position_uncertainty,
-                                                       check_matched_source_position=check_matched_source_position,
-                                                       source_position_tolerance=source_position_tolerance,
-                                                       source_position_sigma=source_position_sigma,
-                                                       force_no_add_image=force_no_add_image,
-                                                       restrict_image_number=restrict_image_number,
-                                                       max_num_images=max_num_images)
         self._flux_ratio_likelihood = flux_ratio_likelihood
         self._kwargs_flux_compute = kwargs_flux_compute
-        if self._flux_ratio_likelihood is True:
-            self.flux_ratio_likelihood = FluxRatioLikelihood(lens_model_class, flux_ratios, flux_ratio_errors,
-                                                             **self._kwargs_flux_compute)
         self._check_bounds = check_bounds
         self._custom_logL_addition = custom_logL_addition
+        self._kwargs_time_delay = {'time_delays_measured': time_delays_measured,
+                                   'time_delays_uncertainties': time_delays_uncertainties}
+        self._kwargs_imaging = {'multi_band_list': multi_band_list, 'multi_band_type': multi_band_type,
+                                'bands_compute': bands_compute,
+                                'image_likelihood_mask_list': image_likelihood_mask_list, 'source_marg': source_marg,
+                                'linear_prior': linear_prior, 'check_positive_flux': check_positive_flux}
+        self._kwargs_position = {'astrometric_likelihood': astrometric_likelihood,
+                                 'image_position_likelihood': image_position_likelihood,
+                                 'source_position_likelihood': source_position_likelihood,
+                                 'ra_image_list': ra_image_list, 'dec_image_list': dec_image_list,
+                                 'image_position_uncertainty': image_position_uncertainty,
+                                 'check_matched_source_position': check_matched_source_position,
+                                 'source_position_tolerance': source_position_tolerance,
+                                 'source_position_sigma': source_position_sigma,
+                                 'force_no_add_image': force_no_add_image,
+                                 'restrict_image_number': restrict_image_number, 'max_num_images': max_num_images}
+        self._kwargs_flux = {'flux_ratios': flux_ratios, 'flux_ratio_errors': flux_ratio_errors}
+        self._kwargs_flux.update(self._kwargs_flux_compute)
+        self._class_instances(kwargs_model=kwargs_model, kwargs_imaging=self._kwargs_imaging,
+                              kwargs_position=self._kwargs_position, kwargs_flux=self._kwargs_flux,
+                              kwargs_time_delay=self._kwargs_time_delay)
 
-    @staticmethod
-    def _unpack_data(multi_band_list=[], multi_band_type='multi-linear', time_delays_measured=None,
-                     time_delays_uncertainties=None, flux_ratios=None, flux_ratio_errors=None, ra_image_list=[],
-                     dec_image_list=[]):
+    def _class_instances(self, kwargs_model, kwargs_imaging, kwargs_position, kwargs_flux, kwargs_time_delay):
         """
 
-        :param multi_band_list: list of [[kwargs_data, kwargs_psf, kwargs_numerics], [], ...]
-        :param multi_band_type: string, type of multi-plane settings (multi-linear or joint-linear)
-        :param time_delays_measured: measured time delays (units of days)
-        :param time_delays_uncertainties: uncertainties in time-delay measurement
-        :param flux_ratios: flux ratios of point sources
-        :param flux_ratio_errors: error in flux ratio measurement
-        :return:
+        :param kwargs_model: lenstronomy model keyword arguments
+        :param kwargs_imaging: keyword arguments for imaging likelihood
+        :param kwargs_position: keyword arguments for positional likelihood
+        :param kwargs_flux: keyword arguments for flux ratio likelihood
+        :param kwargs_time_delay: keyword arguments for time delay likelihood
+        :return: updated model instances of this class
         """
-        return multi_band_list, multi_band_type, time_delays_measured, time_delays_uncertainties, flux_ratios, flux_ratio_errors, ra_image_list, dec_image_list
 
-    def _reset_point_source_cache(self, bool=True):
-        self.PointSource.delete_lens_model_cache()
-        self.PointSource.set_save_cache(bool)
+        lens_model_class, source_model_class, lens_light_model_class, point_source_class, extinction_class = class_creator.create_class_instances(**kwargs_model)
+        self.PointSource = point_source_class
+
+        if self._time_delay_likelihood is True:
+            self.time_delay_likelihood = TimeDelayLikelihood(lens_model_class=lens_model_class,
+                                                             point_source_class=point_source_class,
+                                                             **kwargs_time_delay)
+
         if self._image_likelihood is True:
-            self.image_likelihood.reset_point_source_cache(bool)
+            self.image_likelihood = ImageLikelihood(kwargs_model=kwargs_model, **kwargs_imaging)
+        self._position_likelihood = PositionLikelihood(point_source_class, **kwargs_position)
+        if self._flux_ratio_likelihood is True:
+            self.flux_ratio_likelihood = FluxRatioLikelihood(lens_model_class, **kwargs_flux)
+
+    def __call__(self, a):
+        return self.logL(a)
 
     def logL(self, args, verbose=False):
         """
@@ -153,6 +155,8 @@ class LikelihoodModule(object):
                                                                                    kwargs_return['kwargs_lens_light'], \
                                                                                    kwargs_return['kwargs_ps'], \
                                                                                    kwargs_return['kwargs_special']
+        # update model instance in case of changes affecting it (i.e. redshift sampling in multi-plane)
+        self._update_model(kwargs_special)
         # generate image and computes likelihood
         self._reset_point_source_cache(bool=True)
         logL = 0
@@ -235,9 +239,6 @@ class LikelihoodModule(object):
         num_param, param_names = self.param.num_param()
         return self.num_data - num_param - num_linear
 
-    def __call__(self, a):
-        return self.logL(a)
-
     def likelihood(self, a):
         return self.logL(a)
 
@@ -249,3 +250,40 @@ class LikelihoodModule(object):
         :return: -logL
         """
         return -self.logL(a)
+
+    @staticmethod
+    def _unpack_data(multi_band_list=[], multi_band_type='multi-linear', time_delays_measured=None,
+                     time_delays_uncertainties=None, flux_ratios=None, flux_ratio_errors=None, ra_image_list=[],
+                     dec_image_list=[]):
+        """
+
+        :param multi_band_list: list of [[kwargs_data, kwargs_psf, kwargs_numerics], [], ...]
+        :param multi_band_type: string, type of multi-plane settings (multi-linear or joint-linear)
+        :param time_delays_measured: measured time delays (units of days)
+        :param time_delays_uncertainties: uncertainties in time-delay measurement
+        :param flux_ratios: flux ratios of point sources
+        :param flux_ratio_errors: error in flux ratio measurement
+        :return:
+        """
+        return multi_band_list, multi_band_type, time_delays_measured, time_delays_uncertainties, flux_ratios, flux_ratio_errors, ra_image_list, dec_image_list
+
+    def _reset_point_source_cache(self, bool=True):
+        self.PointSource.delete_lens_model_cache()
+        self.PointSource.set_save_cache(bool)
+        if self._image_likelihood is True:
+            self.image_likelihood.reset_point_source_cache(bool)
+
+    def _update_model(self, kwargs_special):
+        """
+        updates lens model instance of this class (and all class instances related to it) when an update to the
+        modeled redshifts of the deflector and/or source planes are made
+
+        :param kwargs_special: keyword arguments from SpecialParam() class return of sampling arguments
+        :return: None, all class instances updated to recent modek
+        """
+        kwargs_model, update_bool = self.param.update_kwargs_model(kwargs_special)
+        if update_bool is True:
+            self._class_instances(kwargs_model=kwargs_model, kwargs_imaging=self._kwargs_imaging,
+                                  kwargs_position=self._kwargs_position, kwargs_flux=self._kwargs_flux,
+                                  kwargs_time_delay=self._kwargs_time_delay)
+        # TODO remove redundancies with Param() calls updates

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -133,7 +133,8 @@ class Param(object):
         if lens_redshift_sampling_indexes is not None:
             num_z_sampling = int(np.max(lens_redshift_sampling_indexes) + 1)
         if source_redshift_sampling_indexes is not None:
-            num_z_sampling = np.max(num_z_sampling, np.max(source_redshift_sampling_indexes) + 1)
+            num_z_source = int(np.max(source_redshift_sampling_indexes) + 1)
+            num_z_sampling = max(num_z_sampling, num_z_source)
         self._num_z_sampling, self._lens_redshift_sampling_indexes, self._source_redshift_sampling_indexes = num_z_sampling, lens_redshift_sampling_indexes, source_redshift_sampling_indexes
 
         self._lens_model_class, self._source_model_class, _, _, _ = class_creator.create_class_instances(all_models=True, **kwargs_model)

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -9,9 +9,7 @@ class SpecialParam(object):
 
     def __init__(self, Ddt_sampling=False, mass_scaling=False, num_scale_factor=1, kwargs_fixed=None, kwargs_lower=None,
                  kwargs_upper=None, point_source_offset=False, source_size=False, num_images=0, num_tau0=0,
-                 num_z_lens=0,
-                 lens_redshift_sampling_indexes=None, lens_redshift_list=None,
-                 source_redshift_sampling_indexes=None, source_redshift_list=None):
+                 num_z_sampling=0):
         """
 
         :param Ddt_sampling: bool, if True, samples the time-delay distance D_dt (in units of Mpc)
@@ -25,13 +23,7 @@ class SpecialParam(object):
         :param num_images: number of point source images such that the point source offset parameters match their numbers
         :param source_size: bool, if True, samples a source size parameters to be evaluated in the flux ratio likelihood.
         :param num_tau0: integer, number of different optical depth re-normalization factors
-        :param num_z_lens: integer, number of different lens redshifts to be sampled
-        :param lens_redshift_sampling_indexes: list of integers corresponding to the lens model components whose redshifts
-         are a free parameter (only has an effect in multi-plane lensing) with same indexes indicating joint redshift,
-         in ascending numbering e.g. [-1, 0, 0, 1, 0, 2], -1 indicating not sampled fixed indexes
-        :param source_redshift_sampling_indexes: list of integers corresponding to the source model components whose redshifts
-         are a free parameter (only has an effect in multi-plane lensing) with same indexes indicating joint redshift,
-         in ascending numbering e.g. [-1, 0, 0, 1, 0, 2], -1 indicating not sampled fixed indexes
+        :param num_z_sampling: integer, number of different lens redshifts to be sampled
         """
 
         self._D_dt_sampling = Ddt_sampling
@@ -40,11 +32,11 @@ class SpecialParam(object):
         self._point_source_offset = point_source_offset
         self._num_images = num_images
         self._num_tau0 = num_tau0
-        self._num_z_lens = num_z_lens
-        if num_z_lens > 0:
-            self._z_lens_sampling = True
+        self._num_z_sampling = num_z_sampling
+        if num_z_sampling > 0:
+            self._z_sampling = True
         else:
-            self._z_lens_sampling = False
+            self._z_sampling = False
 
         if kwargs_fixed is None:
             kwargs_fixed = {}
@@ -63,8 +55,8 @@ class SpecialParam(object):
                 kwargs_lower['source_size'] = 0
             if self._num_tau0 > 0:
                 kwargs_lower['tau0_list'] = [0] * self._num_tau0
-            if self._z_lens_sampling is True:
-                kwargs_lower['z_lens_sampling'] = [0] * self._num_z_lens
+            if self._z_sampling is True:
+                kwargs_lower['z_sampling'] = [0] * self._num_z_sampling
         if kwargs_upper is None:
             kwargs_upper = {}
             if self._D_dt_sampling is True:
@@ -78,8 +70,8 @@ class SpecialParam(object):
                 kwargs_upper[source_size] = 1
             if self._num_tau0 > 0:
                 kwargs_upper['tau0_list'] = [1000] * self._num_tau0
-            if self._z_lens_sampling is True:
-                kwargs_upper['z_lens_sampling'] = [20] * self._num_z_lens
+            if self._z_sampling is True:
+                kwargs_upper['z_sampling'] = [20] * self._num_z_sampling
         self.lower_limit = kwargs_lower
         self.upper_limit = kwargs_upper
 
@@ -126,12 +118,12 @@ class SpecialParam(object):
                 i += self._num_tau0
             else:
                 kwargs_special['tau0_list'] = self._kwargs_fixed['tau0_list']
-        if self._z_lens_sampling is True:
-            if 'z_lens_sampling' not in self._kwargs_fixed:
-                kwargs_special['z_lens_sampling'] = args[i:i + self._num_z_lens]
-                i += self._num_z_lens
+        if self._z_sampling is True:
+            if 'z_sampling' not in self._kwargs_fixed:
+                kwargs_special['z_sampling'] = args[i:i + self._num_z_sampling]
+                i += self._num_z_sampling
             else:
-                kwargs_special['z_lens_sampling'] = self._kwargs_fixed['z_lens_sampling']
+                kwargs_special['z_sampling'] = self._kwargs_fixed['z_sampling']
         return kwargs_special, i
 
     def set_params(self, kwargs_special):
@@ -162,10 +154,10 @@ class SpecialParam(object):
             if 'tau0_list' not in self._kwargs_fixed:
                 for i in range(self._num_tau0):
                     args.append(kwargs_special['tau0_list'][i])
-        if self._z_lens_sampling is True:
-            if 'z_lens_sampling' not in self._kwargs_fixed:
-                for i in range(self._num_z_lens):
-                    args.append(kwargs_special['z_lens_sampling'][i])
+        if self._z_sampling is True:
+            if 'z_sampling' not in self._kwargs_fixed:
+                for i in range(self._num_z_sampling):
+                    args.append(kwargs_special['z_sampling'][i])
         return args
 
     def num_param(self):
@@ -202,9 +194,9 @@ class SpecialParam(object):
                 num += self._num_tau0
                 for i in range(self._num_tau0):
                     string_list.append('tau0')
-        if self._z_lens_sampling is True:
-            if 'z_lens_sampling' not in self._kwargs_fixed:
-                num += self._num_z_lens
-                for i in range(self._num_z_lens):
-                    string_list.append('z_lens')
+        if self._z_sampling is True:
+            if 'z_sampling' not in self._kwargs_fixed:
+                num += self._num_z_sampling
+                for i in range(self._num_z_sampling):
+                    string_list.append('z')
         return num, string_list

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -6,8 +6,9 @@ class SpecialParam(object):
     These includes cosmology relevant parameters, astrometric errors and overall scaling parameters.
     """
 
-    def __init__(self, Ddt_sampling=False, mass_scaling=False, num_scale_factor=1, kwargs_fixed={}, kwargs_lower=None,
-                 kwargs_upper=None, point_source_offset=False, source_size=False, num_images=0, num_tau0=0):
+    def __init__(self, Ddt_sampling=False, mass_scaling=False, num_scale_factor=1, kwargs_fixed=None, kwargs_lower=None,
+                 kwargs_upper=None, point_source_offset=False, source_size=False, num_images=0, num_tau0=0,
+                 lens_redshift_sampling_indexes=None):
         """
 
         :param Ddt_sampling: bool, if True, samples the time-delay distance D_dt (in units of Mpc)
@@ -17,10 +18,13 @@ class SpecialParam(object):
         :param kwargs_lower: keyword arguments, lower bound of parameters being sampled
         :param kwargs_upper: keyword arguments, upper bound of parameters being sampled
         :param point_source_offset: bool, if True, adds relative offsets ot the modeled image positions relative to the
-        time-delay and lens equation solver
+         time-delay and lens equation solver
         :param num_images: number of point source images such that the point source offset parameters match their numbers
         :param source_size: bool, if True, samples a source size parameters to be evaluated in the flux ratio likelihood.
         :param num_tau0: integer, number of different optical depth re-normalization factors
+        :param lens_redshift_sampling_indexes: list of integers corresponding to the lens model components whose redshifts
+         are a free parameter (only has an effect in multi-plane lensing) with same indexes indicating joint redshift,
+         in ascending numbering e.g. [-1, 0, 0, 1, 0, 2], -1 indicating not sampled fixed indexes and
         """
 
         self._D_dt_sampling = Ddt_sampling
@@ -29,6 +33,8 @@ class SpecialParam(object):
         self._point_source_offset = point_source_offset
         self._num_images = num_images
         self._num_tau0 = num_tau0
+        if kwargs_fixed is None:
+            kwargs_fixed = {}
         self._kwargs_fixed = kwargs_fixed
         self._source_size = source_size
         if kwargs_lower is None:

--- a/test/test_GalKin/test_galkin_model.py
+++ b/test/test_GalKin/test_galkin_model.py
@@ -1,11 +1,9 @@
 __author__ = 'sibirrer'
+
 from lenstronomy.GalKin.galkin_model import GalkinModel
 
-
 import numpy.testing as npt
-import numpy as np
 import pytest
-import unittest
 
 
 class TestGalkinModel(object):
@@ -29,21 +27,13 @@ class TestGalkinModel(object):
         assert out > 0
         print(out)
 
-
         kin_numeric = GalkinModel(kwargs_model, kwargs_cosmo, analytic_kinematics=False, kwargs_numerics=kwargs_numerics)
         out_num = kin_numeric.check_df(r, kwargs_mass=[{'theta_E': theta_E, 'gamma': gamma}],
                                        kwargs_light=[{'Rs': r_eff * 0.551, 'amp': 1}], kwargs_anisotropy={'r_ani': a_ani*r_eff})
         assert out_num > 1
         npt.assert_almost_equal(out_num/out, 1, decimal=2)
-        # import matplotlib.pyplot as plt
-        # import numpy as np
-        # r_list = np.logspace(-1, 1, 20)
-        # crit_list = []
-        # for r in r_list:
-        #    crit_list.append(kin.check_df(r, theta_E, gamma, a_ani, r_eff))
-        # plt.plot(r_list, crit_list)
-        # plt.show()
-        # assert 1 == 0
+
+        kin_numeric_default = GalkinModel(kwargs_model, kwargs_cosmo, analytic_kinematics=False, kwargs_numerics=None)
 
 
 if __name__ == '__main__':

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -128,6 +128,11 @@ class TestLikelihoodModule(object):
         logL = likelihood.logL(args, verbose=True)
         npt.assert_almost_equal(logL, -3080.29, decimal=-1)
 
+    def test_check_bounds(self):
+        penalty, bound_hit = self.Likelihood.check_bounds(args=[0, 1], lowerLimit=[1, 0], upperLimit=[2, 2],
+                                                          verbose=True)
+        assert bound_hit
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -14,8 +14,9 @@ class TestParam(object):
     def setup(self):
         kwargs_model = {'lens_model_list': ['SPEP'], 'source_light_model_list': ['GAUSSIAN'],
                         'lens_light_model_list': ['SERSIC'], 'point_source_model_list': ['LENSED_POSITION'],
-                        'multi_plane': True, 'lens_redshift_list': [0.5], 'z_source': 2}
-        kwargs_param = {'num_point_source_list': [2], 'lens_redshift_sampling_indexes': [0]}
+                        'multi_plane': True, 'lens_redshift_list': [0.5], 'z_source': 2, 'source_redshift_list': [0.5]}
+        kwargs_param = {'num_point_source_list': [2], 'lens_redshift_sampling_indexes': [0],
+                        'source_redshift_sampling_indexes': [0], 'image_plane_source_list': [True]}
         kwargs_fixed_lens = [{'gamma': 1.9}]  # for SPEP lens
         kwargs_fixed_source = [{'sigma': 0.1, 'center_x':0.2, 'center_y': 0.2}]
         kwargs_fixed_ps = [{'ra_image': [-1, 1], 'dec_image': [-1, 1]}]
@@ -246,6 +247,10 @@ class TestParam(object):
         kwargs_ps_out = kwargs_return['kwargs_ps']
         dist = param.check_solver(kwargs_lens=kwargs_lens_out, kwargs_ps=kwargs_ps_out)
         npt.assert_almost_equal(dist, 0, decimal=10)
+
+    def test_num_point_source_images(self):
+        num = self.param_class.num_point_source_images
+        assert num == 2
 
 
 if __name__ == '__main__':

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -13,9 +13,10 @@ class TestParam(object):
 
     def setup(self):
         kwargs_model = {'lens_model_list': ['SPEP'], 'source_light_model_list': ['GAUSSIAN'],
-                          'lens_light_model_list': ['SERSIC'], 'point_source_model_list': ['LENSED_POSITION']}
-        kwargs_param = {'num_point_source_list': [2]}
-        kwargs_fixed_lens = [{'gamma': 1.9}] #for SPEP lens
+                        'lens_light_model_list': ['SERSIC'], 'point_source_model_list': ['LENSED_POSITION'],
+                        'multi_plane': True, 'lens_redshift_list': [0.5], 'z_source': 2}
+        kwargs_param = {'num_point_source_list': [2], 'lens_redshift_sampling_indexes': [0]}
+        kwargs_fixed_lens = [{'gamma': 1.9}]  # for SPEP lens
         kwargs_fixed_source = [{'sigma': 0.1, 'center_x':0.2, 'center_y': 0.2}]
         kwargs_fixed_ps = [{'ra_image': [-1, 1], 'dec_image': [-1, 1]}]
         kwargs_fixed_lens_light = [{}]
@@ -29,7 +30,7 @@ class TestParam(object):
     def test_num_param(self):
         num_param, list = self.param_class.num_param()
         assert list[0] == 'theta_E_lens0'
-        assert num_param == 9
+        assert num_param == 10
 
         kwargs_model = {'lens_model_list': ['SPEP'], 'source_light_model_list': ['GAUSSIAN'],
                         'lens_light_model_list': ['SERSIC'], 'point_source_model_list': ['LENSED_POSITION']}
@@ -59,8 +60,10 @@ class TestParam(object):
                                   'q': 0.86, 'n_sersic': 1.7,
                                   'amp': 11.8, 'R_sersic': 0.697, 'phi_G_2': 0}]
         kwargs_true_ps = [{'point_amp': [1, 1], 'ra_image': [-1, 1], 'dec_image': [-1, 1]}]
-        kwargs_cosmo = [{}]
-        args = self.param_class.kwargs2args(kwargs_true_lens, kwargs_true_source, kwargs_lens_light=kwargs_true_lens_light, kwargs_ps=kwargs_true_ps, kwargs_special=kwargs_cosmo)
+        kwargs_special = {'z_sampling': [0.5]}
+        args = self.param_class.kwargs2args(kwargs_true_lens, kwargs_true_source,
+                                            kwargs_lens_light=kwargs_true_lens_light, kwargs_ps=kwargs_true_ps,
+                                            kwargs_special=kwargs_special)
         kwargs_return = self.param_class.args2kwargs(args)
         lens_dict_list = kwargs_return['kwargs_lens']
         lens_light_dict_list = kwargs_return['kwargs_lens_light']

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -14,15 +14,15 @@ class TestParam(object):
         self.kwargs = {'D_dt': 1988, 'delta_x_image': [0, 0], 'delta_y_image': [0, 0], 'source_size': 0.1, 'tau0_list': [0, 1]}
 
     def test_get_setParams(self):
-        args = self.param.setParams(self.kwargs)
-        kwargs_new, _ = self.param.getParams(args, i=0)
-        args_new = self.param.setParams(kwargs_new)
+        args = self.param.set_params(self.kwargs)
+        kwargs_new, _ = self.param.get_params(args, i=0)
+        args_new = self.param.set_params(kwargs_new)
         for k in range(len(args)):
             npt.assert_almost_equal(args[k], args_new[k], decimal=8)
 
         param_fixed = SpecialParam(Ddt_sampling=True, kwargs_fixed=self.kwargs, point_source_offset=True, num_images=2,
                                    source_size=True)
-        kwargs_new, i = param_fixed.getParams(args=[], i=0)
+        kwargs_new, i = param_fixed.get_params(args=[], i=0)
         kwargs_new['D_dt'] = self.kwargs['D_dt']
 
     def test_num_params(self):
@@ -33,17 +33,17 @@ class TestParam(object):
         kwargs_fixed = {}
         param = SpecialParam(kwargs_fixed=kwargs_fixed, mass_scaling=True, num_scale_factor=3)
         kwargs = {'scale_factor': [0, 1, 2]}
-        args = param.setParams(kwargs)
+        args = param.set_params(kwargs)
         assert len(args) == 3
         num_param, param_list = param.num_param()
         assert num_param == 3
-        kwargs_new, _ = param.getParams(args, i=0)
+        kwargs_new, _ = param.get_params(args, i=0)
         assert kwargs_new['scale_factor'][1] == 1
         param = SpecialParam(kwargs_fixed=kwargs, mass_scaling=True, num_scale_factor=3)
         kwargs_in = {'scale_factor': [9, 9, 9]}
-        args = param.setParams(kwargs_in)
+        args = param.set_params(kwargs_in)
         assert len(args) == 0
-        kwargs_new, _ = param.getParams(args, i=0)
+        kwargs_new, _ = param.get_params(args, i=0)
         print(kwargs_new)
         assert kwargs_new['scale_factor'][1] == 1
 
@@ -52,8 +52,8 @@ class TestParam(object):
                              kwargs_lower={'delta_x_image': [-1, -1], 'delta_y_image': [-1, -1]},
                              kwargs_upper={'delta_x_image': [1, 1], 'delta_y_image': [1, 1]})
         kwargs = {'delta_x_image': [0.5, 0.5], 'delta_y_image': [0.5, 0.5]}
-        args = param.setParams(kwargs_special=kwargs)
-        kwargs_new, _ = param.getParams(args, i=0)
+        args = param.set_params(kwargs_special=kwargs)
+        kwargs_new, _ = param.get_params(args, i=0)
         print(kwargs_new)
         assert kwargs_new['delta_x_image'][0] == kwargs['delta_x_image'][0]
 

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -2,6 +2,7 @@ __author__ = 'sibirrer'
 
 import pytest
 import numpy.testing as npt
+import numpy as np
 from lenstronomy.Sampling.special_param import SpecialParam
 
 
@@ -10,8 +11,9 @@ class TestParam(object):
     def setup(self):
         kwargs_fixed = {}
         self.param = SpecialParam(Ddt_sampling=True, kwargs_fixed=kwargs_fixed, point_source_offset=True, num_images=2,
-                                  source_size=True, num_tau0=2)
-        self.kwargs = {'D_dt': 1988, 'delta_x_image': [0, 0], 'delta_y_image': [0, 0], 'source_size': 0.1, 'tau0_list': [0, 1]}
+                                  source_size=True, num_tau0=2, num_z_sampling=3)
+        self.kwargs = {'D_dt': 1988, 'delta_x_image': [0, 0], 'delta_y_image': [0, 0], 'source_size': 0.1,
+                       'tau0_list': [0, 1], 'z_sampling': np.array([0.1, 0.5, 2])}
 
     def test_get_setParams(self):
         args = self.param.set_params(self.kwargs)
@@ -27,7 +29,7 @@ class TestParam(object):
 
     def test_num_params(self):
         num, list = self.param.num_param()
-        assert num == 8
+        assert num == 11
 
     def test_mass_scaling(self):
         kwargs_fixed = {}

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -9,8 +9,7 @@ from lenstronomy.Sampling.special_param import SpecialParam
 class TestParam(object):
 
     def setup(self):
-        kwargs_fixed = {}
-        self.param = SpecialParam(Ddt_sampling=True, kwargs_fixed=kwargs_fixed, point_source_offset=True, num_images=2,
+        self.param = SpecialParam(Ddt_sampling=True, kwargs_fixed=None, point_source_offset=True, num_images=2,
                                   source_size=True, num_tau0=2, num_z_sampling=3)
         self.kwargs = {'D_dt': 1988, 'delta_x_image': [0, 0], 'delta_y_image': [0, 0], 'source_size': 0.1,
                        'tau0_list': [0, 1], 'z_sampling': np.array([0.1, 0.5, 2])}
@@ -23,7 +22,7 @@ class TestParam(object):
             npt.assert_almost_equal(args[k], args_new[k], decimal=8)
 
         param_fixed = SpecialParam(Ddt_sampling=True, kwargs_fixed=self.kwargs, point_source_offset=True, num_images=2,
-                                   source_size=True)
+                                   source_size=True, num_z_sampling=3, num_tau0=2)
         kwargs_new, i = param_fixed.get_params(args=[], i=0)
         kwargs_new['D_dt'] = self.kwargs['D_dt']
 


### PR DESCRIPTION
allows to chose specific redshifts in multi-plane lensing (for deflectors and source planes) to vary during the fitting. The current design of lenstronomy assigns redshifts in the pre-defined model components as the cosmological dependent relative distances for the ray-tracing are pre-computed for speed up. The current work-around is computationally not optimal as it requires to re-instantiate likelihood classes on the fly.