### PR TITLE
Propagate missing shapelets parameter to Parameters class

### DIFF
--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -119,6 +119,7 @@ class Param(object):
          the sample as for the lens
         :param source_grid_offset: optional, if True when using a pixel-based modelling (e.g. with STARLETS-like profiles),
         adds two additional sampled parameters describing RA/Dec offsets between data coordinate grid and pixelated source plane coordinate grid.
+        :param num_shapelet_lens: number of shapelet coefficients in the 'SHAPELETS_CART' or 'SHAPELETS_POLAR' mass profile.
         """
 
         self._lens_model_list = kwargs_model.get('lens_model_list', [])

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -68,7 +68,7 @@ class Param(object):
                  joint_lens_with_source_light=[], mass_scaling_list=None, point_source_offset=False,
                  num_point_source_list=None, image_plane_source_list=None, solver_type='NONE', Ddt_sampling=None,
                  source_size=False, num_tau0=0, lens_redshift_sampling_indexes=None,
-                 source_redshift_sampling_indexes=None, source_grid_offset=False):
+                 source_redshift_sampling_indexes=None, source_grid_offset=False, num_shapelet_lens=0):
         """
 
         :param kwargs_model:
@@ -219,7 +219,7 @@ class Param(object):
                                                             self._joint_lens_light_with_point_source)
         self.lensParams = LensParam(self._lens_model_list, kwargs_fixed_lens_updated, num_images=self._num_images,
                                     solver_type=self._solver_type, kwargs_lower=kwargs_lower_lens,
-                                    kwargs_upper=kwargs_upper_lens)
+                                    kwargs_upper=kwargs_upper_lens, num_shapelet_lens=num_shapelet_lens)
         self.lensLightParams = LightParam(self._lens_light_model_list, kwargs_fixed_lens_light_updated, type='lens_light',
                                           linear_solver=linear_solver, kwargs_lower=kwargs_lower_lens_light,
                                           kwargs_upper=kwargs_upper_lens_light)

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -252,6 +252,21 @@ class TestParam(object):
         num = self.param_class.num_point_source_images
         assert num == 2
 
+    def test_shapelet_lens(self):
+        kwargs_model = {'lens_model_list': ['SHAPELETS_CART'], 'source_light_model_list': [],
+                        'lens_light_model_list': [], 'point_source_model_list': []}
+        kwargs_param = {'num_shapelet_lens': 6}
+        kwargs_fixed_lens = [{'beta': 1}]  # for SPEP lens
+        kwargs_fixed_source = [{}]
+        kwargs_fixed_ps = [{}]
+        kwargs_fixed_lens_light = [{}]
+        kwargs_fixed_cosmo = [{}]
+        self.param_class = Param(kwargs_model, kwargs_fixed_lens=kwargs_fixed_lens,
+                                 kwargs_fixed_source=kwargs_fixed_source,
+                                 kwargs_fixed_lens_light=kwargs_fixed_lens_light, kwargs_fixed_ps=kwargs_fixed_ps,
+                                 kwargs_fixed_special=kwargs_fixed_cosmo, **kwargs_param)
+        self.param_class.print_setting()
+
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This is to allow the use of shapelets in the mass within e.g. the FittingSequence.