### PR TITLE
Optional shorter APIs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Key contributors
 Contributors (alphabetic)
 -------------------------
 
+* Jelle Aalbers `JelleAalbers <https://github.com/JelleAalbers>`_
 * Joel Akeret `jakeret <https://github.com/jakeret/>`_
 * Adam Amara `aamara <https://github.com/aamara/>`_
 * Xuheng Ding `dartoon <https://github.com/dartoon/>`_

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Example notebooks
 We have made an extension module available at `https://github.com/sibirrer/lenstronomy_extensions <https://github.com/sibirrer/lenstronomy_extensions>`_.
 You can find simple examle notebooks for various cases. The latest versions of the notebooks should be compatible with the recent pip version of lenstronomy.
 
-* `Units, coordiante system and parameter definitions in lenstronomy <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/units_coordinates_parameters.ipynb>`_
+* `Units, coordinate system and parameter definitions in lenstronomy <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/units_coordinates_parameters.ipynb>`_
 * `FITS handling and extracting needed information from the data prior to modeling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/fits_handling.ipynb>`_
 * `Modeling a simple Einstein ring <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/simple_ring.ipynb>`_
 * `Quadrupoly lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/quad_model.ipynb>`_

--- a/lenstronomy/Analysis/image_reconstruction.py
+++ b/lenstronomy/Analysis/image_reconstruction.py
@@ -4,7 +4,11 @@ import numpy as np
 import lenstronomy.Util.class_creator as class_creator
 from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class MultiBandImageReconstruction(object):
     """
     this class manages the output/results of a fitting process and can conveniently access image reconstruction
@@ -94,6 +98,7 @@ class MultiBandImageReconstruction(object):
         return self.model_band_list[i].image_model_class, self.model_band_list[i].kwargs_model
 
 
+@export
 class ModelBand(object):
     """
     class to plot a single band given the full modeling results
@@ -158,6 +163,7 @@ class ModelBand(object):
         return kwargs_return
 
 
+@export
 def check_solver_error(image):
     """
 

--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -10,6 +10,8 @@ from lenstronomy.Analysis.lens_profile import LensProfileAnalysis
 from lenstronomy.Analysis.light_profile import LightProfileAnalysis
 import lenstronomy.Util.multi_gauss_expansion as mge
 
+__all__ = ['KinematicsAPI']
+
 
 class KinematicsAPI(object):
     """

--- a/lenstronomy/Analysis/lens_profile.py
+++ b/lenstronomy/Analysis/lens_profile.py
@@ -4,6 +4,8 @@ from lenstronomy.Util import mask_util as mask_util
 import lenstronomy.Util.multi_gauss_expansion as mge
 from lenstronomy.Util import analysis_util
 
+__all__ = ['LensProfileAnalysis']
+
 
 class LensProfileAnalysis(object):
     """

--- a/lenstronomy/Analysis/light2mass.py
+++ b/lenstronomy/Analysis/light2mass.py
@@ -2,6 +2,8 @@ import numpy as np
 from lenstronomy.Util import util
 from lenstronomy.LightModel.light_model import LightModel
 
+__all__ = ['light2mass_interpol']
+
 
 def light2mass_interpol(lens_light_model_list, kwargs_lens_light, numPix=100, deltaPix=0.05, subgrid_res=5,
                         center_x=0, center_y=0):

--- a/lenstronomy/Analysis/light_profile.py
+++ b/lenstronomy/Analysis/light_profile.py
@@ -4,6 +4,8 @@ import lenstronomy.Util.util as util
 import lenstronomy.Util.analysis_util as analysis_util
 import lenstronomy.Util.multi_gauss_expansion as mge
 
+__all__ = ['LightProfileAnalysis']
+
 
 class LightProfileAnalysis(object):
     """

--- a/lenstronomy/Analysis/td_cosmography.py
+++ b/lenstronomy/Analysis/td_cosmography.py
@@ -3,11 +3,12 @@ __author__ = 'sibirrer'
 
 import numpy as np
 from astropy.cosmology import default_cosmology
-
 from lenstronomy.Util import class_creator
 from lenstronomy.Util import constants as const
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from lenstronomy.Analysis.kinematics_api import KinematicsAPI
+
+__all__ = ['TDCosmography']
 
 
 class TDCosmography(KinematicsAPI):

--- a/lenstronomy/Cosmo/background.py
+++ b/lenstronomy/Cosmo/background.py
@@ -4,6 +4,8 @@ __author__ = 'sibirrer'
 import numpy as np
 import lenstronomy.Util.constants as const
 
+__all__ = ['Background']
+
 
 class Background(object):
     """

--- a/lenstronomy/Cosmo/cosmo_solver.py
+++ b/lenstronomy/Cosmo/cosmo_solver.py
@@ -7,7 +7,11 @@ import numpy as np
 from astropy.cosmology import FlatLambdaCDM
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def cosmo2angular_diameter_distances(H_0, omega_m, z_lens, z_source):
     """
 
@@ -25,6 +29,7 @@ def cosmo2angular_diameter_distances(H_0, omega_m, z_lens, z_source):
     return Dd, Ds/Dds
 
 
+@export
 def ddt2h0(ddt, z_lens, z_source, cosmo):
     """
     converts time-delay distance to H0 for a given expansion history
@@ -42,6 +47,7 @@ def ddt2h0(ddt, z_lens, z_source, cosmo):
     return h0
 
 
+@export
 class SolverFlatLCDM(object):
     """
     class to solve multidimensional non-linear equations to determine the cosmological parameters H0 and omega_m given
@@ -74,6 +80,7 @@ class SolverFlatLCDM(object):
         return x
 
 
+@export
 class InvertCosmo(object):
     """
     class to do an interpolation and call the inverse of this interpolation to get H_0 and omega_m

--- a/lenstronomy/Cosmo/kde_likelihood.py
+++ b/lenstronomy/Cosmo/kde_likelihood.py
@@ -1,6 +1,8 @@
 import numpy as np
 from scipy import stats
 
+__all__ = ['KDELikelihood']
+
 
 class KDELikelihood(object):
     """

--- a/lenstronomy/Cosmo/lcdm.py
+++ b/lenstronomy/Cosmo/lcdm.py
@@ -3,6 +3,8 @@ __author__ = 'sibirrer'
 from astropy.cosmology import FlatLambdaCDM, LambdaCDM
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 
+__all__ = ['LCDM']
+
 
 class LCDM(object):
     """

--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -7,6 +7,8 @@ import lenstronomy.Util.constants as const
 from lenstronomy.Cosmo.background import Background
 from lenstronomy.Cosmo.nfw_param import NFWParam
 
+__all__ = ['LensCosmo']
+
 
 class LensCosmo(object):
     """

--- a/lenstronomy/Cosmo/nfw_param.py
+++ b/lenstronomy/Cosmo/nfw_param.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+__all__ = ['NFWParam']
+
 
 class NFWParam(object):
     """

--- a/lenstronomy/Data/coord_transforms.py
+++ b/lenstronomy/Data/coord_transforms.py
@@ -2,7 +2,11 @@ import numpy.linalg as linalg
 import numpy as np
 import lenstronomy.Util.util as util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Coordinates(object):
     """
     class to handle linear coordinate transformations of a square pixel image
@@ -132,6 +136,7 @@ class Coordinates(object):
                                                                     self._Ma2pix)
 
 
+@export
 class Coordinates1D(Coordinates):
     """
     coordinate grid described in 1-d arrays

--- a/lenstronomy/Data/image_noise.py
+++ b/lenstronomy/Data/image_noise.py
@@ -2,6 +2,11 @@ import numpy as np
 from lenstronomy.Util import image_util
 
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
+
+@export
 class ImageNoise(object):
     """
     class that deals with noise properties of imaging data
@@ -94,6 +99,7 @@ class ImageNoise(object):
             return covariance_matrix(model, self._background_rms, self._exp_map, self._gradient_boost_factor)
 
 
+@export
 def covariance_matrix(data, background_rms, exposure_map, gradient_boost_factor=None):
     """
     returns a diagonal matrix for the covariance estimation which describes the error

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -3,6 +3,8 @@ import numpy as np
 from lenstronomy.Data.pixel_grid import PixelGrid
 from lenstronomy.Data.image_noise import ImageNoise
 
+__all__ = ['ImageData']
+
 
 class ImageData(PixelGrid, ImageNoise):
     """

--- a/lenstronomy/Data/pixel_grid.py
+++ b/lenstronomy/Data/pixel_grid.py
@@ -1,6 +1,8 @@
 import numpy as np
 from lenstronomy.Data.coord_transforms import Coordinates, Coordinates1D
 
+__all__ = ['PixelGrid']
+
 
 class PixelGrid(Coordinates):
     """

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -3,6 +3,8 @@ import lenstronomy.Util.kernel_util as kernel_util
 import lenstronomy.Util.util as util
 import warnings
 
+__all__ = ['PSF']
+
 
 class PSF(object):
     """

--- a/lenstronomy/GalKin/analytic_kinematics.py
+++ b/lenstronomy/GalKin/analytic_kinematics.py
@@ -9,6 +9,8 @@ from lenstronomy.LensModel.Profiles.spp import SPP
 import lenstronomy.Util.constants as const
 import math
 
+__all__ = ['AnalyticKinematics']
+
 
 class AnalyticKinematics(Anisotropy):
     """

--- a/lenstronomy/GalKin/anisotropy.py
+++ b/lenstronomy/GalKin/anisotropy.py
@@ -3,7 +3,11 @@ import scipy.special as special
 from lenstronomy.GalKin import velocity_util
 from scipy.interpolate import interp1d
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Anisotropy(object):
     """
     class that handles the kinematic anisotropy
@@ -75,6 +79,7 @@ class Anisotropy(object):
             self._model.delete_cache()
 
 
+@export
 class Const(object):
     """
     constant anisotropy model class
@@ -122,6 +127,7 @@ class Const(object):
         raise ValueError('routine not supported yet for constant anisotropy model!')
 
 
+@export
 class Isotropic(object):
     """
     class for isotropic (beta=0) stellar orbits
@@ -166,6 +172,7 @@ class Isotropic(object):
         return 1
 
 
+@export
 class Radial(object):
     """
     class for radial (beta=1) stellar orbits
@@ -209,6 +216,7 @@ class Radial(object):
         return r**2
 
 
+@export
 class OsipkovMerritt(object):
     """
     class for Osipkov&Merrit stellar orbits
@@ -257,6 +265,7 @@ class OsipkovMerritt(object):
         return r**2 + r_ani**2
 
 
+@export
 class GeneralizedOM(object):
     """
     generalized Osipkov&Merrit profile
@@ -385,6 +394,7 @@ class GeneralizedOM(object):
             return np.array(_F_array, dtype=float)
 
 
+@export
 class Colin(object):
     """
     class for stellar orbits anisotropy parameter based on Colin et al. (2000)

--- a/lenstronomy/GalKin/aperture.py
+++ b/lenstronomy/GalKin/aperture.py
@@ -2,6 +2,8 @@ __author__ = 'sibirrer'
 
 from lenstronomy.GalKin.aperture_types import Shell, Slit, IFUShells, Frame
 
+__all__ = ['Aperture']
+
 
 """
 class that defines the aperture of the measurement (e.g. slit, integral field spectroscopy regions etc)
@@ -13,7 +15,6 @@ Available aperture types:
 'shell': r_in, r_out, center_ra, center_dec
 
 """
-
 
 class Aperture(object):
     """

--- a/lenstronomy/GalKin/aperture_types.py
+++ b/lenstronomy/GalKin/aperture_types.py
@@ -2,7 +2,11 @@ __author__ = 'sibirrer'
 
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Slit(object):
     """
     Slit aperture description
@@ -40,6 +44,7 @@ class Slit(object):
         return 1
 
 
+@export
 def slit_select(ra, dec, length, width, center_ra=0, center_dec=0, angle=0):
     """
 
@@ -63,6 +68,7 @@ def slit_select(ra, dec, length, width, center_ra=0, center_dec=0, angle=0):
         return False
 
 
+@export
 class Frame(object):
     """
     rectangular box with a hole in the middle (also rectangular), effectively a frame
@@ -100,6 +106,7 @@ class Frame(object):
         return 1
 
 
+@export
 def frame_select(ra, dec, width_outer, width_inner, center_ra=0, center_dec=0, angle=0):
     """
 
@@ -124,6 +131,7 @@ def frame_select(ra, dec, width_outer, width_inner, center_ra=0, center_dec=0, a
     return False
 
 
+@export
 class Shell(object):
     """
     Shell aperture
@@ -158,6 +166,7 @@ class Shell(object):
         return 1
 
 
+@export
 def shell_select(ra, dec, r_in, r_out, center_ra=0, center_dec=0):
     """
 
@@ -178,6 +187,7 @@ def shell_select(ra, dec, r_in, r_out, center_ra=0, center_dec=0):
         return False
 
 
+@export
 class IFUShells(object):
     """
     class for an Integral Field Unit spectrograph with azimuthal shells where the kinematics are measured
@@ -211,6 +221,7 @@ class IFUShells(object):
         return len(self._r_bins) - 1
 
 
+@export
 def shell_ifu_select(ra, dec, r_bin, center_ra=0, center_dec=0):
     """
 

--- a/lenstronomy/GalKin/cosmo.py
+++ b/lenstronomy/GalKin/cosmo.py
@@ -1,6 +1,8 @@
 import lenstronomy.Util.constants as const
 import numpy as np
 
+__all__ = ['Cosmo']
+
 
 class Cosmo(object):
     """

--- a/lenstronomy/GalKin/galkin.py
+++ b/lenstronomy/GalKin/galkin.py
@@ -3,6 +3,8 @@ from lenstronomy.GalKin.galkin_model import GalkinModel
 
 import numpy as np
 
+__all__ = ['Galkin']
+
 
 class Galkin(GalkinModel, GalkinObservation):
     """

--- a/lenstronomy/GalKin/galkin_model.py
+++ b/lenstronomy/GalKin/galkin_model.py
@@ -1,6 +1,8 @@
 from lenstronomy.GalKin.numeric_kinematics import NumericKinematics
 from lenstronomy.GalKin.analytic_kinematics import AnalyticKinematics
 
+__all__ = ['GalkinModel']
+
 
 class GalkinModel(object):
     """

--- a/lenstronomy/GalKin/galkin_multiobservation.py
+++ b/lenstronomy/GalKin/galkin_multiobservation.py
@@ -3,6 +3,8 @@ from lenstronomy.GalKin.galkin_model import GalkinModel
 
 import numpy as np
 
+__all__ = ['GalkinMultiObservation']
+
 
 class GalkinMultiObservation(GalkinModel):
     """

--- a/lenstronomy/GalKin/light_profile.py
+++ b/lenstronomy/GalKin/light_profile.py
@@ -3,6 +3,8 @@ import copy
 from scipy.interpolate import interp1d
 from lenstronomy.LightModel.light_model import LightModel
 
+__all__ = ['LightProfile']
+
 
 class LightProfile(object):
     """

--- a/lenstronomy/GalKin/numeric_kinematics.py
+++ b/lenstronomy/GalKin/numeric_kinematics.py
@@ -8,6 +8,8 @@ from lenstronomy.GalKin.cosmo import Cosmo
 from lenstronomy.LensModel.single_plane import SinglePlane
 import lenstronomy.GalKin.velocity_util as util
 
+__all__ = ['NumericKinematics']
+
 
 class NumericKinematics(Anisotropy):
 

--- a/lenstronomy/GalKin/observation.py
+++ b/lenstronomy/GalKin/observation.py
@@ -1,6 +1,8 @@
 from lenstronomy.GalKin.aperture import Aperture
 from lenstronomy.GalKin.psf import PSF
 
+__all__ = ['GalkinObservation']
+
 
 class GalkinObservation(PSF, Aperture):
     """

--- a/lenstronomy/GalKin/psf.py
+++ b/lenstronomy/GalKin/psf.py
@@ -1,6 +1,10 @@
 from lenstronomy.GalKin import velocity_util as util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class PSF(object):
     """
     general class to handle the PSF in the GalKin module for rendering the displacement of photons/spectro
@@ -28,6 +32,7 @@ class PSF(object):
         return self._psf.displace_psf(x, y)
 
 
+@export
 class PSF_GAUSSIAN(object):
     """
     Gaussian PSF
@@ -49,6 +54,7 @@ class PSF_GAUSSIAN(object):
         return util.displace_PSF_gaussian(x, y, self._fwhm)
 
 
+@export
 class PSF_MOFFAT(object):
     """
     Moffat PSF

--- a/lenstronomy/GalKin/velocity_util.py
+++ b/lenstronomy/GalKin/velocity_util.py
@@ -3,7 +3,11 @@ __author__ = 'sibirrer'
 import mpmath as mp
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def hyp_2F1(a, b, c, z):
     """
     http://docs.sympy.org/0.7.1/modules/mpmath/functions/hypergeometric.html
@@ -11,6 +15,7 @@ def hyp_2F1(a, b, c, z):
     return mp.hyp2f1(a, b, c, z)
 
 
+@export
 def displace_PSF_gaussian(x, y, FWHM):
     """
 
@@ -26,6 +31,7 @@ def displace_PSF_gaussian(x, y, FWHM):
     return x_, y_
 
 
+@export
 def moffat_r(r, alpha, beta):
     """
     Moffat profile
@@ -38,6 +44,7 @@ def moffat_r(r, alpha, beta):
     return 2. * (beta - 1) / alpha ** 2 * (1 + (r/alpha) ** 2) ** (-beta)
 
 
+@export
 def moffat_fwhm_alpha(FWHM, beta):
     """
     computes alpha parameter from FWHM and beta for a Moffat profile
@@ -49,6 +56,7 @@ def moffat_fwhm_alpha(FWHM, beta):
     return FWHM / (2 * np.sqrt(2 ** (1. / beta) - 1))
 
 
+@export
 def draw_moffat_r(FWHM, beta):
     """
 
@@ -63,6 +71,7 @@ def draw_moffat_r(FWHM, beta):
     return X
 
 
+@export
 def displace_PSF_moffat(x, y, FWHM, beta):
     """
 
@@ -77,6 +86,7 @@ def displace_PSF_moffat(x, y, FWHM, beta):
     return x + dx, y + dy
 
 
+@export
 def draw_cdf_Y(beta):
     """
     Draw c.d.f for Moffat function according to Berge et al. Ufig paper, equation B2
@@ -88,6 +98,7 @@ def draw_cdf_Y(beta):
     return (1-x) ** (1./(1-beta))
 
 
+@export
 def project2d_random(r):
     """
     draws a random projection from radius r in 2d and 1d
@@ -102,6 +113,7 @@ def project2d_random(r):
     return R, x, y
 
 
+@export
 def draw_xy(R):
     """
 
@@ -114,6 +126,7 @@ def draw_xy(R):
     return x, y
 
 
+@export
 def draw_hernquist(a):
     """
 

--- a/lenstronomy/ImSim/MultiBand/joint_linear.py
+++ b/lenstronomy/ImSim/MultiBand/joint_linear.py
@@ -3,6 +3,8 @@ import lenstronomy.ImSim.de_lens as de_lens
 
 import numpy as np
 
+__all__ = ['JointLinear']
+
 
 class JointLinear(MultiLinear):
     """

--- a/lenstronomy/ImSim/MultiBand/multi_data_base.py
+++ b/lenstronomy/ImSim/MultiBand/multi_data_base.py
@@ -1,3 +1,4 @@
+__all__ = ['MultiDataBase']
 
 
 class MultiDataBase(object):

--- a/lenstronomy/ImSim/MultiBand/multi_linear.py
+++ b/lenstronomy/ImSim/MultiBand/multi_linear.py
@@ -1,6 +1,8 @@
 from lenstronomy.ImSim.MultiBand.multi_data_base import MultiDataBase
 from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
 
+__all__ = ['MultiLinear']
+
 
 class MultiLinear(MultiDataBase):
     """

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -3,6 +3,8 @@ from lenstronomy.Data.imaging_data import ImageData
 from lenstronomy.Data.psf import PSF
 from lenstronomy.Util import class_creator
 
+__all__ = ['SingleBandMultiModel']
+
 
 class SingleBandMultiModel(ImageLinearFit):
     """

--- a/lenstronomy/ImSim/Numerics/adaptive_numerics.py
+++ b/lenstronomy/ImSim/Numerics/adaptive_numerics.py
@@ -3,6 +3,8 @@ from lenstronomy.ImSim.Numerics.convolution import PixelKernelConvolution
 from lenstronomy.Util import kernel_util
 from lenstronomy.Util import image_util
 
+__all__ = ['AdaptiveConvolution']
+
 
 class AdaptiveConvolution(object):
     """

--- a/lenstronomy/ImSim/Numerics/convolution.py
+++ b/lenstronomy/ImSim/Numerics/convolution.py
@@ -9,6 +9,9 @@ import lenstronomy.Util.kernel_util as kernel_util
 import lenstronomy.Util.util as util
 import lenstronomy.Util.image_util as image_util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
 
 def _centered(arr, newshape):
     # Return the center newshape portion of the array.
@@ -20,6 +23,7 @@ def _centered(arr, newshape):
     return arr[tuple(myslice)]
 
 
+@export
 class PixelKernelConvolution(object):
     """
     class to compute convolutions for a given pixelized kernel (fft, grid)
@@ -175,6 +179,7 @@ class PixelKernelConvolution(object):
         return self.convolution2d(image_low_res)
 
 
+@export
 class SubgridKernelConvolution(object):
     """
     class to compute the convolution on a supersampled grid with partial convolution computed on the regular grid
@@ -231,6 +236,7 @@ class SubgridKernelConvolution(object):
         return image_resized_conv
 
 
+@export
 class MultiGaussianConvolution(object):
     """
     class to perform a convolution consisting of multiple 2d Gaussians
@@ -304,6 +310,7 @@ class MultiGaussianConvolution(object):
         return kernel / np.sum(kernel)
 
 
+@export
 class FWHMGaussianConvolution(object):
     """
     uses a two-dimensional Gaussian function with same FWHM of given kernel as approximation
@@ -330,6 +337,7 @@ class FWHMGaussianConvolution(object):
         return image_conv
 
 
+@export
 class MGEConvolution(object):
     """
     approximates a 2d kernel with an azimuthal Multi-Gaussian expansion

--- a/lenstronomy/ImSim/Numerics/grid.py
+++ b/lenstronomy/ImSim/Numerics/grid.py
@@ -3,7 +3,11 @@ from lenstronomy.Util import util
 from lenstronomy.Util import image_util
 from lenstronomy.Data.coord_transforms import Coordinates1D
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class AdaptiveGrid(Coordinates1D):
     """
     manages a super-sampled grid on the partial image
@@ -151,6 +155,7 @@ class AdaptiveGrid(Coordinates1D):
         return grid2d
 
 
+@export
 class RegularGrid(Coordinates1D):
     """
     manages a super-sampled grid on the partial image

--- a/lenstronomy/ImSim/Numerics/numba_convolution.py
+++ b/lenstronomy/ImSim/Numerics/numba_convolution.py
@@ -4,6 +4,8 @@ from lenstronomy.Util import numba_util
 from lenstronomy.ImSim.Numerics.partial_image import PartialImage
 from lenstronomy.Util import image_util
 
+__all__ = ['NumbaConvolution']
+
 
 class NumbaConvolution(object):
     """

--- a/lenstronomy/ImSim/Numerics/numerics.py
+++ b/lenstronomy/ImSim/Numerics/numerics.py
@@ -5,6 +5,8 @@ from lenstronomy.Util import util
 from lenstronomy.Util import kernel_util
 import numpy as np
 
+__all__ = ['Numerics']
+
 
 class Numerics(PointSourceRendering):
     """

--- a/lenstronomy/ImSim/Numerics/numerics_subframe.py
+++ b/lenstronomy/ImSim/Numerics/numerics_subframe.py
@@ -3,6 +3,8 @@ from lenstronomy.ImSim.Numerics.numerics import Numerics
 from lenstronomy.ImSim.Numerics.point_source_rendering import PointSourceRendering
 from lenstronomy.Data.pixel_grid import PixelGrid
 
+__all__ = ['NumericsSubFrame']
+
 
 class NumericsSubFrame(PointSourceRendering):
     """

--- a/lenstronomy/ImSim/Numerics/partial_image.py
+++ b/lenstronomy/ImSim/Numerics/partial_image.py
@@ -1,6 +1,8 @@
 import numpy as np
 import lenstronomy.Util.util as util
 
+__all__ = ['PartialImage']
+
 
 class PartialImage(object):
     """

--- a/lenstronomy/ImSim/Numerics/point_source_rendering.py
+++ b/lenstronomy/ImSim/Numerics/point_source_rendering.py
@@ -2,6 +2,8 @@ from lenstronomy.Util import image_util
 from lenstronomy.Util import kernel_util
 import numpy as np
 
+__all__ = ['PointSourceRendering']
+
 
 class PointSourceRendering(object):
     """

--- a/lenstronomy/ImSim/de_lens.py
+++ b/lenstronomy/ImSim/de_lens.py
@@ -3,7 +3,11 @@ __author__ = 'sibirrer'
 import numpy as np
 import sys
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def get_param_WLS(A, C_D_inv, d, inv_bool=True):
     """
     returns the parameter values given
@@ -38,6 +42,7 @@ def get_param_WLS(A, C_D_inv, d, inv_bool=True):
     return B, M_inv, image
 
 
+@export
 def marginalisation_const(M_inv):
     """
     get marginalisation constant 1/2 log(M_beta) for flat priors
@@ -51,6 +56,7 @@ def marginalisation_const(M_inv):
     return sign * log_det/2
 
 
+@export
 def marginalization_new(M_inv, d_prior=None):
     """
 

--- a/lenstronomy/ImSim/differential_extinction.py
+++ b/lenstronomy/ImSim/differential_extinction.py
@@ -1,6 +1,8 @@
 from lenstronomy.LightModel.light_model import LightModel
 import numpy as np
 
+__all__ = ['DifferentialExtinction']
+
 
 class DifferentialExtinction(object):
     """

--- a/lenstronomy/ImSim/image2source_mapping.py
+++ b/lenstronomy/ImSim/image2source_mapping.py
@@ -1,6 +1,8 @@
 import numpy as np
 from lenstronomy.Cosmo.background import Background
 
+__all__ = ['Image2SourceMapping']
+
 
 class Image2SourceMapping(object):
     """

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -3,6 +3,8 @@ import lenstronomy.ImSim.de_lens as de_lens
 from lenstronomy.Util import util
 import numpy as np
 
+__all__ = ['ImageLinearFit']
+
 
 class ImageLinearFit(ImageModel):
     """

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -10,6 +10,8 @@ from lenstronomy.Util import util
 
 import numpy as np
 
+__all__ = ['ImageModel']
+
 
 class ImageModel(object):
     """

--- a/lenstronomy/LensModel/LightConeSim/light_cone.py
+++ b/lenstronomy/LensModel/LightConeSim/light_cone.py
@@ -5,6 +5,8 @@ from lenstronomy.Util import constants as const
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from lenstronomy.LensModel.lens_model import LensModel
 
+__all__ = ['LightCone', 'MassSlice']
+
 
 class LightCone(object):
     """

--- a/lenstronomy/LensModel/Optimizer/fixed_routines.py
+++ b/lenstronomy/LensModel/Optimizer/fixed_routines.py
@@ -3,6 +3,11 @@ from lenstronomy.Util.param_util import shear_polar2cartesian,shear_cartesian2po
     ellipticity2phi_q
 from lenstronomy.Util.util import approx_theta_E
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
+
+@export
 class FixedShearPowerLaw(object):
 
     _fixshear = True
@@ -91,6 +96,7 @@ class FixedShearPowerLaw(object):
 
         return sie_list_low+shear_list_low,sie_list_high+shear_list_high
 
+@export
 class FixedPowerLaw_Shear(object):
 
     def __init__(self,lens_model_list,kwargs_lens,xpos,ypos,constrain_params):
@@ -208,6 +214,7 @@ class FixedPowerLaw_Shear(object):
 
         return sie_list_low+shear_list_low,sie_list_high+shear_list_high
 
+@export
 class VariablePowerLaw_Shear(object):
 
     def __init__(self,lens_model_list,kwargs_lens,xpos,ypos,constrain_params):

--- a/lenstronomy/LensModel/Optimizer/multi_plane_optimizer.py
+++ b/lenstronomy/LensModel/Optimizer/multi_plane_optimizer.py
@@ -1,6 +1,8 @@
 from lenstronomy.LensModel.lens_model import LensModel
 import numpy as np
 
+__all__ = ['MultiPlaneLensing', 'Foreground']
+
 
 class MultiPlaneLensing(object):
     # TODO documentation of role of this class

--- a/lenstronomy/LensModel/Optimizer/optimizer.py
+++ b/lenstronomy/LensModel/Optimizer/optimizer.py
@@ -10,6 +10,8 @@ from lenstronomy.LensModel.Optimizer.penalties import Penalties
 from scipy.optimize import minimize
 from lenstronomy.LensModel.Solver.lens_equation_solver import LensEquationSolver
 
+__all__ = ['Optimizer']
+
 
 class Optimizer(object):
 

--- a/lenstronomy/LensModel/Optimizer/optimizer_params.py
+++ b/lenstronomy/LensModel/Optimizer/optimizer_params.py
@@ -1,4 +1,5 @@
 from lenstronomy.LensModel.Optimizer.fixed_routines import *
+from lenstronomy.Util.param_util import shear_polar2cartesian, shear_cartesian2polar
 import numpy as np
 
 __all__ = ['Params']

--- a/lenstronomy/LensModel/Optimizer/optimizer_params.py
+++ b/lenstronomy/LensModel/Optimizer/optimizer_params.py
@@ -1,6 +1,8 @@
 from lenstronomy.LensModel.Optimizer.fixed_routines import *
 import numpy as np
 
+__all__ = ['Params']
+
 
 class Params(object):
 

--- a/lenstronomy/LensModel/Optimizer/particle_swarm.py
+++ b/lenstronomy/LensModel/Optimizer/particle_swarm.py
@@ -6,6 +6,8 @@ import numpy
 This class is adapted from the CosmoHammer Particle Swarm Optimizer routine.
 """
 
+__all__ = ['ParticleSwarmOptimizer']
+
 
 class ParticleSwarmOptimizer(object):
 

--- a/lenstronomy/LensModel/Optimizer/penalties.py
+++ b/lenstronomy/LensModel/Optimizer/penalties.py
@@ -1,6 +1,9 @@
 import numpy as np
-from lenstronomy.Util.param_util import cart2polar,polar2cart
+from lenstronomy.Util.param_util import cart2polar
 from lenstronomy.Util.util import sort_image_index
+
+__all__ = ['Penalties']
+
 
 class Penalties(object):
 

--- a/lenstronomy/LensModel/Optimizer/single_plane_optimizer.py
+++ b/lenstronomy/LensModel/Optimizer/single_plane_optimizer.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+__all__ = ['SinglePlaneLensing']
+
 
 class SinglePlaneLensing(object):
 

--- a/lenstronomy/LensModel/Profiles/alpha_shift.py
+++ b/lenstronomy/LensModel/Profiles/alpha_shift.py
@@ -3,6 +3,8 @@ __author__ = 'sibirrer'
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import numpy as np
 
+__all__ = ['Shift']
+
 
 class Shift(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/arc_perturbations.py
+++ b/lenstronomy/LensModel/Profiles/arc_perturbations.py
@@ -3,6 +3,8 @@ from lenstronomy.Util import param_util
 from lenstronomy.Util import derivative_util
 import numpy as np
 
+__all__ = ['ArcPerturbations']
+
 
 class ArcPerturbations(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/base_profile.py
+++ b/lenstronomy/LensModel/Profiles/base_profile.py
@@ -1,3 +1,6 @@
+__all__ = ['LensProfileBase']
+
+
 class LensProfileBase(object):
     """
     this class acts as the base class of all lens model functions and indicates raise statements and default outputs

--- a/lenstronomy/LensModel/Profiles/chameleon.py
+++ b/lenstronomy/LensModel/Profiles/chameleon.py
@@ -4,7 +4,11 @@ from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import lenstronomy.Util.param_util as param_util
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Chameleon(LensProfileBase):
     """
     class of the Chameleon model (See Suyu+2014) an elliptical truncated double isothermal profile
@@ -146,6 +150,7 @@ class Chameleon(LensProfileBase):
         self._nie_2.set_dynamic()
 
 
+@export
 class DoubleChameleon(LensProfileBase):
     """
     class of the Chameleon model (See Suyu+2014) an elliptical truncated double isothermal profile
@@ -240,6 +245,7 @@ class DoubleChameleon(LensProfileBase):
         self._chameleon_2.set_dynamic()
 
 
+@export
 class TripleChameleon(LensProfileBase):
     """
     class of the Chameleon model (See Suyu+2014) an elliptical truncated double isothermal profile
@@ -363,6 +369,7 @@ class TripleChameleon(LensProfileBase):
         self._chameleon_3.set_dynamic()
 
 
+@export
 class DoubleChameleonPointMass(LensProfileBase):
     """
     class of the Chameleon model (See Suyu+2014) an elliptical truncated double isothermal profile

--- a/lenstronomy/LensModel/Profiles/cnfw.py
+++ b/lenstronomy/LensModel/Profiles/cnfw.py
@@ -5,6 +5,8 @@ from scipy.integrate import quad
 from lenstronomy.LensModel.Profiles.nfw import NFW
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['CNFW']
+
 
 class CNFW(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/cnfw_ellipse.py
+++ b/lenstronomy/LensModel/Profiles/cnfw_ellipse.py
@@ -8,6 +8,8 @@ from lenstronomy.LensModel.Profiles.cnfw import CNFW
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['CNFW_ELLIPSE']
+
 
 class CNFW_ELLIPSE(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/const_mag.py
+++ b/lenstronomy/LensModel/Profiles/const_mag.py
@@ -4,6 +4,9 @@ import numpy as np
 import lenstronomy.Util.util as util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['ConstMag']
+
+
 class ConstMag(LensProfileBase):
     """
     this class implements the macromodel potential of `Diego et al. <https://www.aanda.org/articles/aa/pdf/2019/07/aa35490-19.pdf>`_

--- a/lenstronomy/LensModel/Profiles/convergence.py
+++ b/lenstronomy/LensModel/Profiles/convergence.py
@@ -3,6 +3,8 @@ __author__ = 'sibirrer'
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Convergence']
+
 
 class Convergence(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/coreBurkert.py
+++ b/lenstronomy/LensModel/Profiles/coreBurkert.py
@@ -3,6 +3,8 @@ __author__ = 'dgilman'
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['CoreBurkert']
+
 
 class CoreBurkert(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/cored_density.py
+++ b/lenstronomy/LensModel/Profiles/cored_density.py
@@ -4,6 +4,8 @@ import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from lenstronomy.Util import derivative_util as calc_util
 
+__all__ = ['CoredDensity']
+
 
 class CoredDensity(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/cored_density_2.py
+++ b/lenstronomy/LensModel/Profiles/cored_density_2.py
@@ -5,6 +5,8 @@ from scipy.integrate import quad
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from lenstronomy.Util import derivative_util as calc_util
 
+__all__ = ['CoredDensity2']
+
 
 class CoredDensity2(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/cored_density_mst.py
+++ b/lenstronomy/LensModel/Profiles/cored_density_mst.py
@@ -5,6 +5,8 @@ from lenstronomy.LensModel.Profiles.cored_density import CoredDensity
 from lenstronomy.LensModel.Profiles.cored_density_2 import CoredDensity2
 from lenstronomy.LensModel.Profiles.convergence import Convergence
 
+__all__ = ['CoredDensityMST']
+
 
 class CoredDensityMST(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/curved_arc.py
+++ b/lenstronomy/LensModel/Profiles/curved_arc.py
@@ -2,6 +2,8 @@ import numpy as np
 from lenstronomy.LensModel.Profiles.spp import SPP
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['CurvedArc']
+
 
 class CurvedArc(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/dipole.py
+++ b/lenstronomy/LensModel/Profiles/dipole.py
@@ -4,6 +4,8 @@ __author__ = 'sibirrer'
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Dipole', 'Dipole_util']
+
 
 class Dipole(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/epl.py
+++ b/lenstronomy/LensModel/Profiles/epl.py
@@ -6,6 +6,8 @@ import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from scipy.special import hyp2f1
 
+__all__ = ['EPL', 'EPLMajorAxis']
+
 
 class EPL(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/flexion.py
+++ b/lenstronomy/LensModel/Profiles/flexion.py
@@ -1,5 +1,7 @@
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Flexion']
+
 
 class Flexion(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/flexionfg.py
+++ b/lenstronomy/LensModel/Profiles/flexionfg.py
@@ -1,6 +1,8 @@
 from lenstronomy.LensModel.Profiles.flexion import Flexion
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Flexionfg']
+
 
 class Flexionfg(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/gauss_decomposition.py
+++ b/lenstronomy/LensModel/Profiles/gauss_decomposition.py
@@ -15,9 +15,13 @@ from lenstronomy.LensModel.Profiles.gaussian_ellipse_kappa import GaussianEllips
 from lenstronomy.LensModel.Profiles.sersic_utils import SersicUtil
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
 _SQRT_2PI = np.sqrt(2*np.pi)
 
 
+@export
 class GaussianEllipseKappaSet(LensProfileBase):
     """
     This class computes the lensing properties of a set of concentric
@@ -199,6 +203,7 @@ class GaussianEllipseKappaSet(LensProfileBase):
         return density_2d
 
 
+@export
 class GaussDecompositionAbstract(with_metaclass(abc.ABCMeta)):
     """
     This abstract class sets up a template for computing lensing properties of
@@ -429,6 +434,7 @@ class GaussDecompositionAbstract(with_metaclass(abc.ABCMeta)):
                                                    center_x, center_y)
 
 
+@export
 class SersicEllipseGaussDec(GaussDecompositionAbstract):
     """
     This class computes the lensing properties of an elliptical Sersic
@@ -490,6 +496,7 @@ class SersicEllipseGaussDec(GaussDecompositionAbstract):
         return kwargs['R_sersic']
 
 
+@export
 class NFWEllipseGaussDec(GaussDecompositionAbstract):
     """
     This class computes the lensing properties of an elliptical, projected NFW
@@ -590,6 +597,7 @@ class NFWEllipseGaussDec(GaussDecompositionAbstract):
         return kwargs['Rs']
 
 
+@export
 class GaussDecompositionAbstract3D(GaussDecompositionAbstract):
     """
     This abstract class sets up a template for computing lensing properties of
@@ -615,6 +623,7 @@ class GaussDecompositionAbstract3D(GaussDecompositionAbstract):
         return f_sigmas * sigmas * _SQRT_2PI, sigmas
 
 
+@export
 class CTNFWGaussDec(GaussDecompositionAbstract3D):
     """
     This class computes the lensing properties of an projection from a

--- a/lenstronomy/LensModel/Profiles/gaussian_ellipse_kappa.py
+++ b/lenstronomy/LensModel/Profiles/gaussian_ellipse_kappa.py
@@ -15,6 +15,8 @@ from lenstronomy.LensModel.Profiles.gaussian_kappa import GaussianKappa
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['GaussianEllipseKappa']
+
 
 class GaussianEllipseKappa(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/gaussian_ellipse_potential.py
+++ b/lenstronomy/LensModel/Profiles/gaussian_ellipse_potential.py
@@ -6,6 +6,8 @@ from lenstronomy.LensModel.Profiles.gaussian_kappa import GaussianKappa
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['GaussianEllipsePotential']
+
 
 class GaussianEllipsePotential(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/gaussian_kappa.py
+++ b/lenstronomy/LensModel/Profiles/gaussian_kappa.py
@@ -7,6 +7,8 @@ import scipy.integrate as integrate
 from lenstronomy.LensModel.Profiles.gaussian_potential import Gaussian
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['GaussianKappa']
+
 
 class GaussianKappa(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/gaussian_potential.py
+++ b/lenstronomy/LensModel/Profiles/gaussian_potential.py
@@ -4,6 +4,8 @@ __author__ = 'sibirrer'
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Gaussian']
+
 
 class Gaussian(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/hernquist.py
+++ b/lenstronomy/LensModel/Profiles/hernquist.py
@@ -1,6 +1,8 @@
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Hernquist']
+
 
 class Hernquist(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/hernquist_ellipse.py
+++ b/lenstronomy/LensModel/Profiles/hernquist_ellipse.py
@@ -3,6 +3,8 @@ import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import numpy as np
 
+__all__ = ['Hernquist_Ellipse']
+
 
 class Hernquist_Ellipse(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/hessian.py
+++ b/lenstronomy/LensModel/Profiles/hessian.py
@@ -2,6 +2,8 @@ __author__ = 'sibirrer'
 
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Hessian']
+
 
 class Hessian(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/interpol.py
+++ b/lenstronomy/LensModel/Profiles/interpol.py
@@ -6,6 +6,8 @@ import numpy as np
 import lenstronomy.Util.util as util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Interpol', 'InterpolScaled']
+
 
 class Interpol(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/multi_gaussian_kappa.py
+++ b/lenstronomy/LensModel/Profiles/multi_gaussian_kappa.py
@@ -3,6 +3,8 @@ from lenstronomy.LensModel.Profiles.gaussian_kappa import GaussianKappa
 from lenstronomy.LensModel.Profiles.gaussian_ellipse_potential import GaussianEllipsePotential
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['MultiGaussianKappa', 'MultiGaussianKappaEllipse']
+
 
 class MultiGaussianKappa(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/multipole.py
+++ b/lenstronomy/LensModel/Profiles/multipole.py
@@ -5,6 +5,8 @@ import numpy as np
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Multipole']
+
 
 class Multipole(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/nfw.py
+++ b/lenstronomy/LensModel/Profiles/nfw.py
@@ -5,6 +5,8 @@ import numpy as np
 import scipy.interpolate as interp
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['NFW']
+
 
 class NFW(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/nfw_ellipse.py
+++ b/lenstronomy/LensModel/Profiles/nfw_ellipse.py
@@ -5,6 +5,8 @@ from lenstronomy.LensModel.Profiles.nfw import NFW
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['NFW_ELLIPSE']
+
 
 class NFW_ELLIPSE(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/nfw_mass_concentration.py
+++ b/lenstronomy/LensModel/Profiles/nfw_mass_concentration.py
@@ -5,6 +5,8 @@ from lenstronomy.LensModel.Profiles.nfw import NFW
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['NFWMC']
+
 
 class NFWMC(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/nfw_vir_trunc.py
+++ b/lenstronomy/LensModel/Profiles/nfw_vir_trunc.py
@@ -8,6 +8,8 @@ from lenstronomy.Util import  constants as const
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 
+__all__ = ['NFWVirTrunc']
+
 
 class NFWVirTrunc(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/nie.py
+++ b/lenstronomy/LensModel/Profiles/nie.py
@@ -5,6 +5,8 @@ import lenstronomy.Util.util as util
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['NIE', 'NIEMajorAxis']
+
 
 class NIE(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/nie_potential.py
+++ b/lenstronomy/LensModel/Profiles/nie_potential.py
@@ -5,6 +5,9 @@ import lenstronomy.Util.util as util
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['NIE_POTENTIAL', 'NIEPotentialMajorAxis']
+
+
 class NIE_POTENTIAL(LensProfileBase):
     """
     this class implements the elliptical potential of Eq. (67) of `LECTURES ON GRAVITATIONAL LENSING <https://arxiv.org/pdf/astro-ph/9606001.pdf>`_ 

--- a/lenstronomy/LensModel/Profiles/numerical_deflections.py
+++ b/lenstronomy/LensModel/Profiles/numerical_deflections.py
@@ -7,6 +7,8 @@ __author__ = 'dgilman'
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['NumericalAlpha']
+
 
 class NumericalAlpha(LensProfileBase):
 

--- a/lenstronomy/LensModel/Profiles/p_jaffe.py
+++ b/lenstronomy/LensModel/Profiles/p_jaffe.py
@@ -1,6 +1,8 @@
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['PJaffe']
+
 
 class PJaffe(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/p_jaffe_ellipse.py
+++ b/lenstronomy/LensModel/Profiles/p_jaffe_ellipse.py
@@ -3,6 +3,8 @@ import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import numpy as np
 
+__all__ = ['PJaffe_Ellipse']
+
 
 class PJaffe_Ellipse(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/pemd.py
+++ b/lenstronomy/LensModel/Profiles/pemd.py
@@ -4,6 +4,8 @@ from lenstronomy.LensModel.Profiles.spp import SPP
 from lenstronomy.LensModel.Profiles.spemd import SPEMD
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['PEMD']
+
 
 class PEMD(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/point_mass.py
+++ b/lenstronomy/LensModel/Profiles/point_mass.py
@@ -4,6 +4,8 @@ __author__ = 'sibirrer'
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['PointMass']
+
 
 class PointMass(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/sersic.py
+++ b/lenstronomy/LensModel/Profiles/sersic.py
@@ -6,6 +6,8 @@ import lenstronomy.Util.util as util
 from lenstronomy.LensModel.Profiles.sersic_utils import SersicUtil
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['Sersic']
+
 
 class Sersic(SersicUtil, LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/sersic_ellipse_kappa.py
+++ b/lenstronomy/LensModel/Profiles/sersic_ellipse_kappa.py
@@ -6,6 +6,8 @@ from lenstronomy.LensModel.Profiles.sersic import Sersic
 from lenstronomy.Util import param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['SersicEllipseKappa']
+
 
 class SersicEllipseKappa(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/sersic_ellipse_potential.py
+++ b/lenstronomy/LensModel/Profiles/sersic_ellipse_potential.py
@@ -6,6 +6,8 @@ from lenstronomy.LensModel.Profiles.sersic import Sersic
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['SersicEllipse']
+
 
 class SersicEllipse(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/sersic_utils.py
+++ b/lenstronomy/LensModel/Profiles/sersic_utils.py
@@ -3,6 +3,8 @@ import numpy as np
 import scipy
 from lenstronomy.Util import param_util
 
+__all__ = ['SersicUtil']
+
 
 class SersicUtil(object):
 

--- a/lenstronomy/LensModel/Profiles/shapelet_pot_cartesian.py
+++ b/lenstronomy/LensModel/Profiles/shapelet_pot_cartesian.py
@@ -7,6 +7,8 @@ import math
 import numpy.polynomial.hermite as hermite
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['CartShapelets']
+
 
 class CartShapelets(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/shapelet_pot_polar.py
+++ b/lenstronomy/LensModel/Profiles/shapelet_pot_polar.py
@@ -9,6 +9,8 @@ import math
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['PolarShapelets']
+
 
 class PolarShapelets(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/shear.py
+++ b/lenstronomy/LensModel/Profiles/shear.py
@@ -4,6 +4,8 @@ import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import numpy as np
 
+__all__ = ['Shear', 'ShearGammaPsi']
+
 
 class Shear(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/sie.py
+++ b/lenstronomy/LensModel/Profiles/sie.py
@@ -1,6 +1,8 @@
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import numpy as np
 
+__all__ = ['SIE']
+
 
 class SIE(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/sis.py
+++ b/lenstronomy/LensModel/Profiles/sis.py
@@ -1,8 +1,9 @@
 __author__ = 'sibirrer'
 
 import numpy as np
-import scipy.special as special
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+
+__all__ = ['SIS']
 
 
 class SIS(LensProfileBase):

--- a/lenstronomy/LensModel/Profiles/sis_truncate.py
+++ b/lenstronomy/LensModel/Profiles/sis_truncate.py
@@ -3,6 +3,8 @@ __author__ = 'sibirrer'
 import numpy as np
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['SIS_truncate']
+
 
 class SIS_truncate(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/spemd.py
+++ b/lenstronomy/LensModel/Profiles/spemd.py
@@ -4,6 +4,8 @@ import numpy as np
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['SPEMD']
+
 
 class SPEMD(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/spep.py
+++ b/lenstronomy/LensModel/Profiles/spep.py
@@ -7,6 +7,8 @@ from lenstronomy.Util import util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from lenstronomy.LensModel.Profiles.spp import SPP
 
+__all__ = ['SPEP']
+
 
 class SPEP(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/spp.py
+++ b/lenstronomy/LensModel/Profiles/spp.py
@@ -5,6 +5,8 @@ import numpy as np
 import scipy.special as special
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['SPP']
+
 
 class SPP(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Profiles/tnfw.py
+++ b/lenstronomy/LensModel/Profiles/tnfw.py
@@ -7,6 +7,8 @@ import numpy as np
 import warnings
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
+__all__ = ['TNFW']
+
 
 class TNFW(LensProfileBase):
     """

--- a/lenstronomy/LensModel/Solver/lens_equation_solver.py
+++ b/lenstronomy/LensModel/Solver/lens_equation_solver.py
@@ -3,6 +3,8 @@ import lenstronomy.Util.util as util
 import lenstronomy.Util.image_util as image_util
 from scipy.optimize import minimize
 
+__all__ = ['LensEquationSolver']
+
 
 class LensEquationSolver(object):
     """

--- a/lenstronomy/LensModel/Solver/solver.py
+++ b/lenstronomy/LensModel/Solver/solver.py
@@ -2,6 +2,8 @@ from lenstronomy.LensModel.Solver.solver2point import Solver2Point
 from lenstronomy.LensModel.Solver.solver4point import Solver4Point
 import numpy as np
 
+__all__ = ['Solver']
+
 
 class Solver(object):
     """

--- a/lenstronomy/LensModel/Solver/solver2point.py
+++ b/lenstronomy/LensModel/Solver/solver2point.py
@@ -5,6 +5,8 @@ import numpy as np
 import copy
 import lenstronomy.Util.param_util as param_util
 
+__all__ = ['Solver2Point']
+
 
 class Solver2Point(object):
     """

--- a/lenstronomy/LensModel/Solver/solver4point.py
+++ b/lenstronomy/LensModel/Solver/solver4point.py
@@ -6,6 +6,8 @@ import scipy.optimize
 import numpy as np
 import copy
 
+__all__ = ['Solver4Point']
+
 
 class Solver4Point(object):
     """

--- a/lenstronomy/LensModel/convergence_integrals.py
+++ b/lenstronomy/LensModel/convergence_integrals.py
@@ -7,7 +7,11 @@ from lenstronomy.Util import kernel_util
 class to compute lensing potentials and deflection angles provided a convergence map
 """
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def potential_from_kappa_grid(kappa, grid_spacing):
     """
     lensing potential on the convergence grid
@@ -25,6 +29,7 @@ def potential_from_kappa_grid(kappa, grid_spacing):
     return f_
 
 
+@export
 def potential_from_kappa_grid_adaptive(kappa_high_res, grid_spacing, low_res_factor, high_res_kernel_size):
     """
     lensing potential on the convergence grid
@@ -50,6 +55,7 @@ def potential_from_kappa_grid_adaptive(kappa_high_res, grid_spacing, low_res_fac
     return f_high_res + f_low_res
 
 
+@export
 def deflection_from_kappa_grid(kappa, grid_spacing):
     """
     deflection angles on the convergence grid
@@ -68,6 +74,7 @@ def deflection_from_kappa_grid(kappa, grid_spacing):
     return f_x, f_y
 
 
+@export
 def deflection_from_kappa_grid_adaptive(kappa_high_res, grid_spacing, low_res_factor, high_res_kernel_size):
     """
     deflection angles on the convergence grid with adaptive FFT
@@ -107,6 +114,7 @@ def deflection_from_kappa_grid_adaptive(kappa_high_res, grid_spacing, low_res_fa
     return f_x, f_y
 
 
+@export
 def potential_kernel(num_pix, delta_pix):
     """
     numerical gridded integration kernel for convergence to lensing kernel with given pixel size
@@ -124,6 +132,7 @@ def potential_kernel(num_pix, delta_pix):
     return kernel
 
 
+@export
 def deflection_kernel(num_pix, delta_pix):
     """
     numerical gridded integration kernel for convergence to deflection angle with given pixel size

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -6,6 +6,8 @@ from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from astropy.cosmology import default_cosmology
 from lenstronomy.Util import constants as const
 
+__all__ = ['LensModel']
+
 
 class LensModel(object):
     """

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -1,7 +1,7 @@
 import numpy as np
 import lenstronomy.Util.util as util
-import lenstronomy.Util.mask_util as mask_util
-import lenstronomy.Util.param_util as param_util
+
+__all__ = ['LensModelExtensions']
 
 
 class LensModelExtensions(object):

--- a/lenstronomy/LensModel/lens_param.py
+++ b/lenstronomy/LensModel/lens_param.py
@@ -1,5 +1,7 @@
 from lenstronomy.LensModel.single_plane import SinglePlane
 
+__all__ = ['LensParam']
+
 
 class LensParam(object):
     """

--- a/lenstronomy/LensModel/multi_plane.py
+++ b/lenstronomy/LensModel/multi_plane.py
@@ -2,7 +2,11 @@ import numpy as np
 from copy import deepcopy
 from lenstronomy.LensModel.multi_plane_base import MultiPlaneBase
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class MultiPlane(object):
     """
     Multi-plane lensing class with option to assign positions of a selected set of lens models in the observed plane.
@@ -271,6 +275,7 @@ class MultiPlane(object):
         self._multi_plane_base.set_dynamic()
 
 
+@export
 class PhysicalLocation(object):
     """
     center_x and center_y kwargs correspond to angular location of deflectors without lensing along the LOS
@@ -280,6 +285,7 @@ class PhysicalLocation(object):
         return kwargs_lens
 
 
+@export
 class LensedLocation(object):
     """
     center_x and center_y kwargs correspond to observed (lensed) locations of deflectors

--- a/lenstronomy/LensModel/multi_plane_base.py
+++ b/lenstronomy/LensModel/multi_plane_base.py
@@ -3,6 +3,8 @@ from lenstronomy.Cosmo.background import Background
 from lenstronomy.LensModel.profile_list_base import ProfileListBase
 import lenstronomy.Util.constants as const
 
+__all__ = ['MultiPlaneBase']
+
 
 class MultiPlaneBase(ProfileListBase):
 

--- a/lenstronomy/LensModel/profile_integrals.py
+++ b/lenstronomy/LensModel/profile_integrals.py
@@ -2,6 +2,8 @@ import copy
 import scipy.integrate as integrate
 import numpy as np
 
+__all__ = ['ProfileIntegrals']
+
 
 class ProfileIntegrals(object):
     """

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -1,4 +1,8 @@
 from lenstronomy.Util.util import convert_bool_list
+
+__all__ = ['ProfileListBase']
+
+
 _SUPPORTED_MODELS = ['SHIFT', 'NIE_POTENTIAL', 'CONST_MAG', 'SHEAR', 'SHEAR_GAMMA_PSI', 'CONVERGENCE', 'FLEXION',
                      'FLEXIONFG', 'POINT_MASS', 'SIS', 'SIS_TRUNCATED', 'SIE', 'SPP', 'NIE', 'NIE_SIMPLE', 'CHAMELEON',
                      'DOUBLE_CHAMELEON', 'TRIPLE_CHAMELEON', 'SPEP', 'PEMD', 'SPEMD', 'EPL', 'NFW', 'NFW_ELLIPSE',
@@ -9,7 +13,6 @@ _SUPPORTED_MODELS = ['SHIFT', 'NIE_POTENTIAL', 'CONST_MAG', 'SHEAR', 'SHEAR_GAMM
                      'MULTI_GAUSSIAN_KAPPA_ELLIPSE', 'INTERPOL', 'INTERPOL_SCALED', 'SHAPELETS_POLAR', 'SHAPELETS_CART',
                      'DIPOLE', 'CURVED_ARC', 'ARC_PERT', 'coreBURKERT', 'CORED_DENSITY', 'CORED_DENSITY_2',
                      'CORED_DENSITY_MST', 'CORED_DENSITY_2_MST', 'NumericalAlpha', 'MULTIPOLE', 'HESSIAN']
-
 
 class ProfileListBase(object):
     """

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -3,6 +3,8 @@ __author__ = 'sibirrer'
 import numpy as np
 from lenstronomy.LensModel.profile_list_base import ProfileListBase
 
+__all__ = ['SinglePlane']
+
 
 class SinglePlane(ProfileListBase):
     """

--- a/lenstronomy/LightModel/Profiles/chameleon.py
+++ b/lenstronomy/LightModel/Profiles/chameleon.py
@@ -2,7 +2,11 @@ from lenstronomy.LightModel.Profiles.nie import NIE
 from lenstronomy.LensModel.Profiles.chameleon import Chameleon as ChameleonLens
 import lenstronomy.Util.param_util as param_util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Chameleon(object):
     """
     class of the Chameleon model (See Suyu+2014) an elliptical truncated double isothermal profile
@@ -39,6 +43,7 @@ class Chameleon(object):
         return flux
 
 
+@export
 class DoubleChameleon(object):
     """
     class of the Chameleon model (See Suyu+2014) an elliptical truncated double isothermal profile
@@ -77,6 +82,7 @@ class DoubleChameleon(object):
         return f_1 + f_2
 
 
+@export
 class TripleChameleon(object):
     """
     class of the Chameleon model (See Suyu+2014) an elliptical truncated double isothermal profile

--- a/lenstronomy/LightModel/Profiles/ellipsoid.py
+++ b/lenstronomy/LightModel/Profiles/ellipsoid.py
@@ -4,6 +4,8 @@ __author__ = 'sibirrer'
 import numpy as np
 from lenstronomy.Util import param_util
 
+__all__ = ['Ellipsoid']
+
 
 class Ellipsoid(object):
     """

--- a/lenstronomy/LightModel/Profiles/gaussian.py
+++ b/lenstronomy/LightModel/Profiles/gaussian.py
@@ -1,7 +1,11 @@
 import numpy as np
 import lenstronomy.Util.param_util as param_util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Gaussian(object):
     """
     class for Gaussian light profile
@@ -56,6 +60,7 @@ class Gaussian(object):
         return self.function(r, 0, amp3d, sigma3d)
 
 
+@export
 class GaussianEllipse(object):
     """
     class for Gaussian light profile with ellipticity
@@ -115,6 +120,7 @@ class GaussianEllipse(object):
         return self.gaussian.light_3d(r, amp, sigma=sigma)
 
 
+@export
 class MultiGaussian(object):
     """
     class for elliptical pseudo Jaffe lens light (2d projected light/mass distribution
@@ -192,6 +198,7 @@ class MultiGaussian(object):
         return f_
 
 
+@export
 class MultiGaussianEllipse(object):
     """
     class for elliptical multi Gaussian profile

--- a/lenstronomy/LightModel/Profiles/hernquist.py
+++ b/lenstronomy/LightModel/Profiles/hernquist.py
@@ -1,5 +1,7 @@
 import lenstronomy.Util.param_util as param_util
 
+__all__ = ['Hernquist', 'HernquistEllipse']
+
 
 class Hernquist(object):
     """

--- a/lenstronomy/LightModel/Profiles/interpolation.py
+++ b/lenstronomy/LightModel/Profiles/interpolation.py
@@ -5,6 +5,8 @@ import numpy as np
 
 import lenstronomy.Util.util as util
 
+__all__ = ['Interpol']
+
 
 class Interpol(object):
     """

--- a/lenstronomy/LightModel/Profiles/moffat.py
+++ b/lenstronomy/LightModel/Profiles/moffat.py
@@ -2,6 +2,8 @@ __author__ = 'sibirrer'
 
 #this file contains a class to make a moffat profile
 
+__all__ = ['Moffat']
+
 
 class Moffat(object):
     """

--- a/lenstronomy/LightModel/Profiles/nie.py
+++ b/lenstronomy/LightModel/Profiles/nie.py
@@ -3,6 +3,8 @@ import lenstronomy.Util.param_util as param_util
 from lenstronomy.Util import util
 from lenstronomy.LightModel.Profiles.profile_base import LightProfileBase
 
+__all__ = ['NIE']
+
 
 class NIE(LightProfileBase):
     """

--- a/lenstronomy/LightModel/Profiles/p_jaffe.py
+++ b/lenstronomy/LightModel/Profiles/p_jaffe.py
@@ -1,5 +1,7 @@
 import lenstronomy.Util.param_util as param_util
 
+__all__ = ['PJaffe', 'PJaffe_Ellipse']
+
 
 class PJaffe(object):
     """

--- a/lenstronomy/LightModel/Profiles/power_law.py
+++ b/lenstronomy/LightModel/Profiles/power_law.py
@@ -3,6 +3,8 @@ from lenstronomy.LensModel.Profiles.spp import SPP
 import numpy as np
 import scipy.special as special
 
+__all__ = ['PowerLaw']
+
 
 class PowerLaw(object):
     """

--- a/lenstronomy/LightModel/Profiles/profile_base.py
+++ b/lenstronomy/LightModel/Profiles/profile_base.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+__all__ = ['LightProfileBase']
+
 
 class LightProfileBase(object):
     """

--- a/lenstronomy/LightModel/Profiles/sersic.py
+++ b/lenstronomy/LightModel/Profiles/sersic.py
@@ -6,7 +6,11 @@ import numpy as np
 from lenstronomy.LensModel.Profiles.sersic_utils import SersicUtil
 import lenstronomy.Util.param_util as param_util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Sersic(SersicUtil):
     """
     this class contains functions to evaluate an spherical Sersic function
@@ -33,6 +37,7 @@ class Sersic(SersicUtil):
         return amp * result
 
 
+@export
 class SersicElliptic(SersicUtil):
     """
     this class contains functions to evaluate an elliptical Sersic function
@@ -64,6 +69,7 @@ class SersicElliptic(SersicUtil):
         return amp * result
 
 
+@export
 class CoreSersic(SersicUtil):
     """
     this class contains the Core-Sersic function introduced by e.g Trujillo et al. 2004

--- a/lenstronomy/LightModel/Profiles/shapelets.py
+++ b/lenstronomy/LightModel/Profiles/shapelets.py
@@ -6,7 +6,11 @@ import math
 
 import lenstronomy.Util.util as util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Shapelets(object):
     """
 
@@ -139,6 +143,7 @@ class Shapelets(object):
         return H_x, H_y
 
 
+@export
 class ShapeletSet(object):
     """
     class to operate on entire shapelet set

--- a/lenstronomy/LightModel/Profiles/shapelets_polar.py
+++ b/lenstronomy/LightModel/Profiles/shapelets_polar.py
@@ -6,7 +6,11 @@ import scipy.special
 
 import lenstronomy.Util.param_util as param_util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class ShapeletsPolar(object):
     """
     2D polar Shapelets, see Massey & Refregier 2005
@@ -147,6 +151,7 @@ class ShapeletsPolar(object):
         return int((n_max+1)*(n_max+2)/2)
 
 
+@export
 class ShapeletsPolarExp(object):
     """
     2D exponential shapelets, Berge et al. 2019
@@ -257,6 +262,7 @@ class ShapeletsPolarExp(object):
         return int(index)
 
 
+@export
 class ShapeletSetPolar(object):
     """
     class to operate on entire shapelet set

--- a/lenstronomy/LightModel/Profiles/starlets.py
+++ b/lenstronomy/LightModel/Profiles/starlets.py
@@ -7,6 +7,8 @@ from lenstronomy.LightModel.Profiles import starlets_util
 from lenstronomy.LightModel.Profiles.interpolation import Interpol
 from lenstronomy.Util import util
 
+__all__ = ['SLIT_Starlets']
+
 
 class SLIT_Starlets(object):
     """

--- a/lenstronomy/LightModel/Profiles/starlets_util.py
+++ b/lenstronomy/LightModel/Profiles/starlets_util.py
@@ -4,7 +4,11 @@ import numpy as np
 import scipy.signal as scs
 import scipy.ndimage.filters as scf
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def transform(img, n_scales, second_gen=False):
     """
     Performs starlet decomposition of an 2D array.
@@ -73,6 +77,7 @@ def transform(img, n_scales, second_gen=False):
     return wave
 
 
+@export
 def inverse_transform(wave, fast=True, second_gen=False):
     """
     Reconstructs an image fron its starlet decomposition coefficients

--- a/lenstronomy/LightModel/Profiles/uniform.py
+++ b/lenstronomy/LightModel/Profiles/uniform.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+__all__ = ['Uniform']
+
 
 class Uniform(object):
     """

--- a/lenstronomy/LightModel/light_model.py
+++ b/lenstronomy/LightModel/light_model.py
@@ -3,6 +3,8 @@ __author__ = 'sibirrer'
 
 from lenstronomy.LightModel.linear_basis import LinearBasis
 
+__all__ = ['LightModel']
+
 
 class LightModel(LinearBasis):
     """

--- a/lenstronomy/LightModel/light_model_base.py
+++ b/lenstronomy/LightModel/light_model_base.py
@@ -4,6 +4,10 @@ __author__ = 'sibirrer'
 
 import numpy as np
 from lenstronomy.Util.util import convert_bool_list
+
+__all__ = ['LightModelBase']
+
+
 _MODELS_SUPPORTED = ['GAUSSIAN', 'GAUSSIAN_ELLIPSE', 'ELLIPSOID', 'MULTI_GAUSSIAN', 'MULTI_GAUSSIAN_ELLIPSE',
                      'SERSIC', 'SERSIC_ELLIPSE', 'CORE_SERSIC', 'SHAPELETS', 'SHAPELETS_POLAR', 'SHAPELETS_POLAR_EXP',
                      'HERNQUIST', 'HERNQUIST_ELLIPSE', 'PJAFFE', 'PJAFFE_ELLIPSE', 'UNIFORM', 'POWER_LAW', 'NIE',

--- a/lenstronomy/LightModel/light_param.py
+++ b/lenstronomy/LightModel/light_param.py
@@ -1,5 +1,7 @@
 from lenstronomy.LightModel.light_model import LightModel
 
+__all__ = ['LightParam']
+
 
 class LightParam(object):
     """

--- a/lenstronomy/LightModel/linear_basis.py
+++ b/lenstronomy/LightModel/linear_basis.py
@@ -5,6 +5,8 @@ __author__ = 'sibirrer'
 import numpy as np
 from lenstronomy.LightModel.light_model_base import LightModelBase
 
+__all__ = ['LinearBasis']
+
 
 class LinearBasis(LightModelBase):
     """

--- a/lenstronomy/Plots/chain_plot.py
+++ b/lenstronomy/Plots/chain_plot.py
@@ -5,6 +5,11 @@ import numpy as np
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
+
+@export
 def plot_chain_list(chain_list, index=0, num_average=100):
     """
     plots the output of a chain of samples (MCMC or PSO) with the some diagnostics of convergence.
@@ -33,6 +38,7 @@ def plot_chain_list(chain_list, index=0, num_average=100):
     return f, axes
 
 
+@export
 def plot_chain(chain, param_list):
     X2_list, pos_list, vel_list = chain
 
@@ -59,6 +65,7 @@ def plot_chain(chain, param_list):
     return f, axes
 
 
+@export
 def plot_mcmc_behaviour(ax, samples_mcmc, param_mcmc, dist_mcmc=None, num_average=100):
     """
     plots the MCMC behaviour and looks for convergence of the chain
@@ -86,6 +93,7 @@ def plot_mcmc_behaviour(ax, samples_mcmc, param_mcmc, dist_mcmc=None, num_averag
     return ax
 
 
+@export
 def psf_iteration_compare(kwargs_psf, **kwargs):
     """
 

--- a/lenstronomy/Plots/lens_plot.py
+++ b/lenstronomy/Plots/lens_plot.py
@@ -9,9 +9,13 @@ from lenstronomy.Data.imaging_data import ImageData
 from lenstronomy.Plots import plot_util
 import scipy.ndimage as ndimage
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
 
 #TODO define coordinate grid beforehand, e.g. kwargs_data
 
+@export
 def lens_model_plot(ax, lensModel, kwargs_lens, numPix=500, deltaPix=0.01, sourcePos_x=0, sourcePos_y=0,
                     point_source=False, with_caustics=False, coord_center_ra=0, coord_center_dec=0,
                     coord_inverse=False):
@@ -66,6 +70,7 @@ def lens_model_plot(ax, lensModel, kwargs_lens, numPix=500, deltaPix=0.01, sourc
     return ax
 
 
+@export
 def distortions(lensModel, kwargs_lens, num_pix=100, delta_pix=0.05, center_ra=0, center_dec=0,
                 differential_scale=0.0001, smoothing_scale=None, **kwargs):
     """
@@ -155,6 +160,7 @@ def distortions(lensModel, kwargs_lens, num_pix=100, delta_pix=0.05, center_ra=0
     return f, axes
 
 
+@export
 def arrival_time_surface(ax, lensModel, kwargs_lens, numPix=500, deltaPix=0.01, sourcePos_x=0, sourcePos_y=0,
                          with_caustics=False, point_source=False, n_levels=10, kwargs_contours={}, image_color_list=None,
                          letter_font_size=20):

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -8,6 +8,8 @@ from lenstronomy.Data.coord_transforms import Coordinates
 from lenstronomy.Plots import plot_util
 from lenstronomy.Analysis.image_reconstruction import ModelBand
 
+__all__ = ['ModelBandPlot']
+
 
 class ModelBandPlot(ModelBand):
     """

--- a/lenstronomy/Plots/model_plot.py
+++ b/lenstronomy/Plots/model_plot.py
@@ -4,6 +4,8 @@ import lenstronomy.Util.class_creator as class_creator
 from lenstronomy.Plots.model_band_plot import ModelBandPlot
 from lenstronomy.Analysis.image_reconstruction import check_solver_error
 
+__all__ = ['ModelPlot']
+
 
 class ModelPlot(object):
     """

--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -2,7 +2,11 @@ import numpy as np
 import math
 from corner.corner import quantile
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def sqrt(inputArray, scale_min=None, scale_max=None):
     """Performs sqrt scaling of the input numpy array.
 
@@ -33,6 +37,7 @@ def sqrt(inputArray, scale_min=None, scale_max=None):
     return imageData
 
 
+@export
 def text_description(ax, d, text, color='w', backgroundcolor='k',
                      flipped=False, font_size=15):
     c_vertical = font_size / 10.**2
@@ -46,6 +51,7 @@ def text_description(ax, d, text, color='w', backgroundcolor='k',
                 backgroundcolor=backgroundcolor)
 
 
+@export
 def scale_bar(ax, d, dist=1., text='1"', color='w', font_size=15, flipped=False):
     if flipped:
         p0 = d - d / 15. - dist
@@ -59,6 +65,7 @@ def scale_bar(ax, d, dist=1., text='1"', color='w', font_size=15, flipped=False)
         ax.text(p0 + dist / 2., p0 + 0.01 * d, text, fontsize=font_size, color=color, ha='center')
 
 
+@export
 def coordinate_arrows(ax, d, coords, color='w', font_size=15, arrow_size=0.05):
     d0 = d / 8.
     p0 = d / 15.
@@ -80,6 +87,7 @@ def coordinate_arrows(ax, d, coords, color='w', font_size=15, arrow_size=0.05):
     ax.text(xx_dec_t * deltaPix, yy_dec_t * deltaPix, "N", color=color, fontsize=font_size, ha='center')
 
 
+@export
 def plot_line_set(ax, coords, ra_caustic_list, dec_caustic_list, shift=0., color='g'):
     """
 
@@ -93,6 +101,7 @@ def plot_line_set(ax, coords, ra_caustic_list, dec_caustic_list, shift=0., color
     return ax
 
 
+@export
 def image_position_plot(ax, coords, ra_image, dec_image, color='w', image_name_list=None):
     """
 
@@ -115,6 +124,7 @@ def image_position_plot(ax, coords, ra_image, dec_image, color='w', image_name_l
     return ax
 
 
+@export
 def source_position_plot(ax, coords, ra_pos, dec_pos):
     """
 
@@ -131,6 +141,7 @@ def source_position_plot(ax, coords, ra_pos, dec_pos):
     return ax
 
 
+@export
 def result_string(x, weights=None, title_fmt=".2f", label=None):
     """
 

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -1,6 +1,9 @@
 import numpy as np
 import copy
 from lenstronomy.PointSource.point_source_types import PointSourceCached
+
+__all__ = ['PointSource']
+
 _SUPPORTED_MODELS = ['UNLENSED', 'LENSED_POSITION', 'SOURCE_POSITION']
 
 

--- a/lenstronomy/PointSource/point_source_param.py
+++ b/lenstronomy/PointSource/point_source_param.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+__all__ = ['PointSourceParam']
+
 
 class PointSourceParam(object):
     """

--- a/lenstronomy/PointSource/point_source_types.py
+++ b/lenstronomy/PointSource/point_source_types.py
@@ -1,7 +1,11 @@
 import numpy as np
 from lenstronomy.LensModel.Solver.lens_equation_solver import LensEquationSolver
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Unlensed(object):
     """
     class of a single point source in the image plane, aka star
@@ -66,6 +70,7 @@ class Unlensed(object):
         pass
 
 
+@export
 class LensedPositions(object):
     """
     class of a a lensed point source parameterized as the (multiple) observed image positions
@@ -188,6 +193,7 @@ class LensedPositions(object):
         self._solver = LensEquationSolver(lens_model_class)
 
 
+@export
 class SourcePositions(object):
     """
     class of a single point source defined in the original source coordinate position that is lensed.
@@ -300,6 +306,7 @@ class SourcePositions(object):
         self._solver = LensEquationSolver(lens_model_class)
 
 
+@export
 class PointSourceCached(object):
     """
     This class is the same as PointSource() except that it sames image and source positions in cache

--- a/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
@@ -1,6 +1,8 @@
 from lenstronomy.LensModel.lens_model_extensions import LensModelExtensions
 import numpy as np
 
+__all__ = ['FluxRatioLikelihood']
+
 
 class FluxRatioLikelihood(object):
     """

--- a/lenstronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/image_likelihood.py
@@ -1,6 +1,8 @@
 import numpy as np
 from lenstronomy.Util import class_creator
 
+__all__ = ['ImageLikelihood']
+
 
 class ImageLikelihood(object):
     """

--- a/lenstronomy/Sampling/Likelihoods/position_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/position_likelihood.py
@@ -1,6 +1,8 @@
 import numpy as np
 from numpy.linalg import inv
 
+__all__ = ['PositionLikelihood']
+
 
 class PositionLikelihood(object):
     """

--- a/lenstronomy/Sampling/Likelihoods/prior_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/prior_likelihood.py
@@ -1,6 +1,8 @@
 import numpy as np
 from lenstronomy.Util.prob_density import KDE1D
 
+__all__ = ['PriorLikelihood']
+
 
 class PriorLikelihood(object):
     """

--- a/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
@@ -1,6 +1,8 @@
 import numpy as np
 import lenstronomy.Util.constants as const
 
+__all__ = ['TimeDelayLikelihood']
+
 
 class TimeDelayLikelihood(object):
     """

--- a/lenstronomy/Sampling/Pool/pool.py
+++ b/lenstronomy/Sampling/Pool/pool.py
@@ -38,6 +38,8 @@ from schwimmbad.serial import SerialPool
 from schwimmbad.mpi import MPIPool
 #from schwimmbad.jl import JoblibPool
 
+__all__ = ['choose_pool']
+
 
 def choose_pool(mpi=False, processes=1, **kwargs):
     """

--- a/lenstronomy/Sampling/Samplers/base_nested_sampler.py
+++ b/lenstronomy/Sampling/Samplers/base_nested_sampler.py
@@ -2,6 +2,8 @@ __author__ = 'aymgal'
 
 import lenstronomy.Util.sampling_util as utils
 
+__all__ = ['NestedSampler']
+
 
 class NestedSampler(object):
     """

--- a/lenstronomy/Sampling/Samplers/dynesty_sampler.py
+++ b/lenstronomy/Sampling/Samplers/dynesty_sampler.py
@@ -5,6 +5,8 @@ import numpy as np
 from lenstronomy.Sampling.Samplers.base_nested_sampler import NestedSampler
 import lenstronomy.Util.sampling_util as utils
 
+__all__ = ['DynestySampler']
+
 
 class DynestySampler(NestedSampler):
     """

--- a/lenstronomy/Sampling/Samplers/multinest_sampler.py
+++ b/lenstronomy/Sampling/Samplers/multinest_sampler.py
@@ -8,6 +8,8 @@ import numpy as np
 from lenstronomy.Sampling.Samplers.base_nested_sampler import NestedSampler
 import lenstronomy.Util.sampling_util as utils
 
+__all__ = ['MultiNestSampler']
+
 
 class MultiNestSampler(NestedSampler):
     """

--- a/lenstronomy/Sampling/Samplers/polychord_sampler.py
+++ b/lenstronomy/Sampling/Samplers/polychord_sampler.py
@@ -9,6 +9,8 @@ import copy
 from lenstronomy.Sampling.Samplers.base_nested_sampler import NestedSampler
 import lenstronomy.Util.sampling_util as utils
 
+__all__ = ['DyPolyChordSampler']
+
 
 class DyPolyChordSampler(NestedSampler):
     """

--- a/lenstronomy/Sampling/Samplers/pso.py
+++ b/lenstronomy/Sampling/Samplers/pso.py
@@ -10,6 +10,8 @@ from math import floor
 import math
 import numpy as np
 
+__all__ = ['ParticleSwarmOptimizer']
+
 
 class ParticleSwarmOptimizer(object):
     """

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -8,6 +8,8 @@ from lenstronomy.Sampling.Likelihoods.prior_likelihood import PriorLikelihood
 import lenstronomy.Util.class_creator as class_creator
 import numpy as np
 
+__all__ = ['LikelihoodModule']
+
 
 class LikelihoodModule(object):
     """

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -10,6 +10,8 @@ from lenstronomy.LightModel.light_param import LightParam
 from lenstronomy.PointSource.point_source_param import PointSourceParam
 from lenstronomy.Sampling.special_param import SpecialParam
 
+__all__ = ['Param']
+
 
 class Param(object):
     """

--- a/lenstronomy/Sampling/sampler.py
+++ b/lenstronomy/Sampling/sampler.py
@@ -9,6 +9,8 @@ from lenstronomy.Sampling.Pool.pool import choose_pool
 import emcee
 from scipy.optimize import minimize
 
+__all__ = ['Sampler']
+
 
 class Sampler(object):
     """

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -1,5 +1,7 @@
 __author__ = 'sibirrer'
 
+__all__ = ['SpecialParam']
+
 
 class SpecialParam(object):
     """

--- a/lenstronomy/SimulationAPI/ObservationConfig/DES.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/DES.py
@@ -4,6 +4,8 @@ https://docs.google.com/spreadsheets/d/1pMUB_OOZWwXON2dd5oP8PekhCT5MBBZJO1HV7IMZ
 sources. """
 import lenstronomy.Util.util as util
 
+__all__ = ['DES']
+
 g_band_obs = {'exposure_time': 90.,
                    'sky_brightness': 22.01,
                    'magnitude_zero_point': 26.58,

--- a/lenstronomy/SimulationAPI/ObservationConfig/Euclid.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/Euclid.py
@@ -4,6 +4,8 @@ https://docs.google.com/spreadsheets/d/1pMUB_OOZWwXON2dd5oP8PekhCT5MBBZJO1HV7IMZ
 sources. """
 import lenstronomy.Util.util as util
 
+__all__ = ['Euclid']
+
 VIS_obs = {'exposure_time': 565.,
                    'sky_brightness': 22.35,
                    'magnitude_zero_point': 24.0,

--- a/lenstronomy/SimulationAPI/ObservationConfig/HST.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/HST.py
@@ -4,6 +4,8 @@ https://docs.google.com/spreadsheets/d/1pMUB_OOZWwXON2dd5oP8PekhCT5MBBZJO1HV7IMZ
 sources. """
 import lenstronomy.Util.util as util
 
+__all__ = ['HST']
+
 # F160W filter configs
 WFC3_F160W_band_obs = {'exposure_time': 5400.,
               'sky_brightness': 22.3,

--- a/lenstronomy/SimulationAPI/ObservationConfig/LSST.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/LSST.py
@@ -4,6 +4,8 @@ https://docs.google.com/spreadsheets/d/1pMUB_OOZWwXON2dd5oP8PekhCT5MBBZJO1HV7IMZ
 sources. """
 import lenstronomy.Util.util as util
 
+__all__ = ['LSST']
+
 u_band_obs = {'exposure_time': 15.,
               'sky_brightness': 22.99,
               'magnitude_zero_point': 26.5,

--- a/lenstronomy/SimulationAPI/ObservationConfig/ZTF.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/ZTF.py
@@ -2,6 +2,8 @@
 
 import lenstronomy.Util.util as util
 
+__all__ = ['ZTF']
+
 """
 Sources
   https://iopscience.iop.org/article/10.1088/1538-3873/aaecbe/pdf

--- a/lenstronomy/SimulationAPI/data_api.py
+++ b/lenstronomy/SimulationAPI/data_api.py
@@ -3,6 +3,8 @@ from lenstronomy.Data.imaging_data import ImageData
 import lenstronomy.Util.util as util
 import numpy as np
 
+__all__ = ['DataAPI']
+
 
 class DataAPI(SingleBand):
     """

--- a/lenstronomy/SimulationAPI/model_api.py
+++ b/lenstronomy/SimulationAPI/model_api.py
@@ -6,6 +6,8 @@ from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 
 import copy
 
+__all__ = ['ModelAPI']
+
 
 class ModelAPI(object):
     """

--- a/lenstronomy/SimulationAPI/observation_api.py
+++ b/lenstronomy/SimulationAPI/observation_api.py
@@ -3,7 +3,11 @@ import warnings
 import lenstronomy.Util.data_util as data_util
 from lenstronomy.Data.psf import PSF
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class Instrument(object):
     """
     basic access points to instrument properties
@@ -23,6 +27,7 @@ class Instrument(object):
         self.pixel_scale = pixel_scale
 
 
+@export
 class Observation(object):
     """
     basic access point to observation properties
@@ -114,6 +119,7 @@ class Observation(object):
         return psf_class
 
 
+@export
 class SingleBand(Instrument, Observation):
     """
     class that combines Instrument and Observation

--- a/lenstronomy/SimulationAPI/observation_constructor.py
+++ b/lenstronomy/SimulationAPI/observation_constructor.py
@@ -4,6 +4,8 @@ import lenstronomy.Util.util as util
 instrument_name_list = ['LSST']
 observation_name_list = ['LSST_g_band', 'LSST_r_band', 'LSST_i_band']
 
+__all__ = ['observation_constructor']
+
 
 def observation_constructor(instrument_name, observation_name):
     """

--- a/lenstronomy/SimulationAPI/point_source_variability.py
+++ b/lenstronomy/SimulationAPI/point_source_variability.py
@@ -3,6 +3,8 @@ from lenstronomy.SimulationAPI.sim_api import SimAPI
 
 import numpy as np
 
+__all__ = ['PointSourceVariability']
+
 
 class PointSourceVariability(object):
     """

--- a/lenstronomy/SimulationAPI/sim_api.py
+++ b/lenstronomy/SimulationAPI/sim_api.py
@@ -5,6 +5,8 @@ from lenstronomy.ImSim.image_model import ImageModel
 import copy
 import numpy as np
 
+__all__ = ['SimAPI']
+
 
 class SimAPI(DataAPI, ModelAPI):
     """

--- a/lenstronomy/Util/analysis_util.py
+++ b/lenstronomy/Util/analysis_util.py
@@ -2,7 +2,11 @@ import numpy as np
 import copy
 import lenstronomy.Util.mask_util as mask_util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def half_light_radius(lens_light, x_grid, y_grid, center_x=0, center_y=0):
     """
 
@@ -25,6 +29,7 @@ def half_light_radius(lens_light, x_grid, y_grid, center_x=0, center_y=0):
     return -1
 
 
+@export
 def radial_profile(light_grid, x_grid, y_grid, center_x=0, center_y=0, n=None):
     """
 
@@ -50,6 +55,7 @@ def radial_profile(light_grid, x_grid, y_grid, center_x=0, center_y=0, n=None):
     return I_r, r
 
 
+@export
 def azimuthalAverage(image, center=None):
     """
 
@@ -89,6 +95,7 @@ def azimuthalAverage(image, center=None):
     return radial_prof, r_bin
 
 
+@export
 def moments(I_xy_input, x, y):
     """
     compute quadrupole moments from a light distribution
@@ -111,6 +118,7 @@ def moments(I_xy_input, x, y):
     return Q_xx, Q_xy, Q_yy, background / np.mean(I_xy)
 
 
+@export
 def ellipticities(I_xy, x, y):
     """
     compute ellipticities of a light distribution
@@ -127,6 +135,7 @@ def ellipticities(I_xy, x, y):
     return e1 / (1+bkg), e2 / (1+bkg)
 
 
+@export
 def bic_model(logL, num_data, num_param):
     """
     Bayesian information criteria
@@ -140,6 +149,7 @@ def bic_model(logL, num_data, num_param):
     return bic
 
 
+@export
 def profile_center(kwargs_list, center_x=None, center_y=None):
     """
     utility routine that results in the centroid estimate for the profile estimates

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -6,7 +6,11 @@ from lenstronomy.PointSource.point_source import PointSource
 from lenstronomy.ImSim.differential_extinction import DifferentialExtinction
 from lenstronomy.ImSim.image_linear_solve import ImageLinearFit
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def create_class_instances(lens_model_list=[], z_lens=None, z_source=None, lens_redshift_list=None,
                            multi_plane=False, observed_convention_index=None, source_light_model_list=[],
                            lens_light_model_list=[], point_source_model_list=[], fixed_magnification_list=None,
@@ -128,6 +132,7 @@ def create_class_instances(lens_model_list=[], z_lens=None, z_source=None, lens_
     return lens_model_class, source_model_class, lens_light_model_class, point_source_class, extinction_class
 
 
+@export
 def create_image_model(kwargs_data, kwargs_psf, kwargs_numerics, kwargs_model, likelihood_mask=None):
     """
 
@@ -145,6 +150,7 @@ def create_image_model(kwargs_data, kwargs_psf, kwargs_numerics, kwargs_model, l
     return imageModel
 
 
+@export
 def create_im_sim(multi_band_list, multi_band_type, kwargs_model, bands_compute=None, likelihood_mask_list=None,
                   band_index=0, kwargs_pixelbased=None):
     """

--- a/lenstronomy/Util/constants.py
+++ b/lenstronomy/Util/constants.py
@@ -6,6 +6,9 @@ this class contains physical constants and conversion factors between units
 """
 import numpy as np
 
+__all__ = ('G c M_sun M_earth AU Mpc day_s arcsec '
+           'a_ES F_ES delay_arcsec2days'.split())
+
 G = 6.67384*10**(-11)  # Gravitational constant [m^3 kg^-1 s^-2]
 c = 299792458  # [m/s]
 

--- a/lenstronomy/Util/correlation.py
+++ b/lenstronomy/Util/correlation.py
@@ -4,7 +4,11 @@ from scipy import fftpack
 import numpy as np
 import lenstronomy.Util.analysis_util as analysis_util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def correlation_2D(image):
     """
     #TODO document normalization output in units
@@ -21,6 +25,7 @@ def correlation_2D(image):
     return np.abs(F2)
 
 
+@export
 def power_spectrum_2d(image):
     """
 
@@ -32,6 +37,7 @@ def power_spectrum_2d(image):
     return (corr2d / nx / ny) ** 2
 
 
+@export
 def power_spectrum_1d(image):
     """
 

--- a/lenstronomy/Util/data_util.py
+++ b/lenstronomy/Util/data_util.py
@@ -1,6 +1,10 @@
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def bkg_noise(readout_noise, exposure_time, sky_brightness, pixel_scale, num_exposures=1):
     """
     computes the expected Gaussian background noise of a pixel in units of counts/second
@@ -19,6 +23,7 @@ def bkg_noise(readout_noise, exposure_time, sky_brightness, pixel_scale, num_exp
     return sigma_bkg
 
 
+@export
 def flux_noise(cps_pixel, exposure_time):
     """
     computes the variance of the shot noise Gaussian approximation of Poisson noise term
@@ -30,6 +35,7 @@ def flux_noise(cps_pixel, exposure_time):
     return cps_pixel / np.sqrt(exposure_time)
 
 
+@export
 def magnitude2cps(magnitude, magnitude_zero_point):
     """
     converts an apparent magnitude to counts per second
@@ -48,6 +54,7 @@ def magnitude2cps(magnitude, magnitude_zero_point):
     return counts
 
 
+@export
 def cps2magnitude(cps, magnitude_zero_point):
     """
 
@@ -60,6 +67,7 @@ def cps2magnitude(cps, magnitude_zero_point):
     return magnitude
 
 
+@export
 def absolute2apparent_magnitude(absolute_magnitude, d_parsec):
     """
     converts absolute to apparent magnitudes
@@ -72,6 +80,7 @@ def absolute2apparent_magnitude(absolute_magnitude, d_parsec):
     return m_apparent
 
 
+@export
 def adu2electrons(adu, ccd_gain):
     """
     converts analog-to-digital units into electron counts
@@ -82,6 +91,7 @@ def adu2electrons(adu, ccd_gain):
     return adu * ccd_gain
 
 
+@export
 def electrons2adu(electrons, ccd_gain):
     """
     converts electron counts into analog-to-digital unit

--- a/lenstronomy/Util/derivative_util.py
+++ b/lenstronomy/Util/derivative_util.py
@@ -3,7 +3,11 @@ routines to compute derivatives of spherical functions
 """
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def d_r_dx(x, y):
     """
     derivative of r with respect to x
@@ -14,6 +18,7 @@ def d_r_dx(x, y):
     return x / np.sqrt(x**2 + y**2)
 
 
+@export
 def d_r_dy(x, y):
     """
     differential dr/dy
@@ -25,6 +30,7 @@ def d_r_dy(x, y):
     return y / np.sqrt(x**2 + y**2)
 
 
+@export
 def d_r_dxx(x, y):
     """
     second derivative dr/dxdx
@@ -35,6 +41,7 @@ def d_r_dxx(x, y):
     return y**2 / (x**2 + y**2)**(3./2)
 
 
+@export
 def d_r_dyy(x, y):
     """
     second derivative dr/dxdx
@@ -45,6 +52,7 @@ def d_r_dyy(x, y):
     return x**2 / (x**2 + y**2)**(3./2)
 
 
+@export
 def d_r_dxy(x, y):
     """
     second derivative dr/dxdx
@@ -55,6 +63,7 @@ def d_r_dxy(x, y):
     return -x * y / (x ** 2 + y ** 2) ** (3 / 2.)
 
 
+@export
 def d_phi_dx(x, y):
     """
     angular derivative in respect to x when phi = arctan2(y, x)
@@ -66,6 +75,7 @@ def d_phi_dx(x, y):
     return -y / (x**2 + y**2)
 
 
+@export
 def d_phi_dy(x, y):
     """
     angular derivative in respect to y when phi = arctan2(y, x)
@@ -77,6 +87,7 @@ def d_phi_dy(x, y):
     return x / (x**2 + y**2)
 
 
+@export
 def d_phi_dxx(x, y):
     """
     second derivative of the orientation angle
@@ -88,6 +99,7 @@ def d_phi_dxx(x, y):
     return 2 * x * y / (x**2 + y**2)**2
 
 
+@export
 def d_phi_dyy(x, y):
     """
     second derivative of the orientation angle in dydy
@@ -99,6 +111,7 @@ def d_phi_dyy(x, y):
     return -2 * x * y / (x ** 2 + y ** 2) ** 2
 
 
+@export
 def d_phi_dxy(x, y):
     """
     second derivative of the orientation angle in dxdy
@@ -110,6 +123,7 @@ def d_phi_dxy(x, y):
     return (-x**2 + y**2) / (x ** 2 + y ** 2) ** 2
 
 
+@export
 def d_x_diffr_dx(x, y):
     """
     derivative of d(x/r)/dx
@@ -122,6 +136,7 @@ def d_x_diffr_dx(x, y):
     return y**2 / (x**2 + y**2)**(3/2.)
 
 
+@export
 def d_y_diffr_dy(x, y):
     """
     derivative of d(y/r)/dy
@@ -134,6 +149,7 @@ def d_y_diffr_dy(x, y):
     return x**2 / (x**2 + y**2)**(3/2.)
 
 
+@export
 def d_y_diffr_dx(x, y):
     """
     derivative of d(y/r)/dx
@@ -146,6 +162,7 @@ def d_y_diffr_dx(x, y):
     return -x*y / (x**2 + y**2)**(3/2.)
 
 
+@export
 def d_x_diffr_dy(x, y):
     """
     derivative of d(x/r)/dy

--- a/lenstronomy/Util/image_util.py
+++ b/lenstronomy/Util/image_util.py
@@ -7,7 +7,11 @@ from scipy.ndimage import interpolation as interp
 import copy
 import lenstronomy.Util.util as util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def add_layer2image(grid2d, x_pos, y_pos, kernel, order=1):
     """
     adds a kernel on the grid2d image at position x_pos, y_pos with an interpolated subgrid pixel shift of order=order
@@ -27,6 +31,7 @@ def add_layer2image(grid2d, x_pos, y_pos, kernel, order=1):
     return add_layer2image_int(grid2d, x_int, y_int, kernel_shifted)
 
 
+@export
 def add_layer2image_int(grid2d, x_pos, y_pos, kernel):
     """
     adds a kernel on the grid2d image at position x_pos, y_pos at integer positions of pixel
@@ -65,6 +70,7 @@ def add_layer2image_int(grid2d, x_pos, y_pos, kernel):
     return new
 
 
+@export
 def add_background(image, sigma_bkd):
     """
     adds background noise to image
@@ -77,6 +83,7 @@ def add_background(image, sigma_bkd):
     return background
 
 
+@export
 def add_poisson(image, exp_time):
     """
     adds a poison (or Gaussian) distributed noise with mean given by surface brightness
@@ -94,6 +101,7 @@ def add_poisson(image, exp_time):
     return poisson
 
 
+@export
 def rotateImage(img, angle):
     """
 
@@ -106,6 +114,7 @@ def rotateImage(img, angle):
     return imgR
 
 
+@export
 def re_size_array(x_in, y_in, input_values, x_out, y_out):
     """
     resizes 2d array (i.e. image) to new coordinates. So far only works with square output aligned with coordinate axis.
@@ -122,6 +131,7 @@ def re_size_array(x_in, y_in, input_values, x_out, y_out):
     return out_values
 
 
+@export
 def symmetry_average(image, symmetry):
     """
     symmetry averaged image
@@ -137,6 +147,7 @@ def symmetry_average(image, symmetry):
     return img_sym
 
 
+@export
 def findOverlap(x_mins, y_mins, min_distance):
     """
     finds overlapping solutions, deletes multiples and deletes non-solutions and if it is not a solution, deleted as well
@@ -156,6 +167,7 @@ def findOverlap(x_mins, y_mins, min_distance):
     return x_mins, y_mins
 
 
+@export
 def coordInImage(x_coord, y_coord, numPix, deltapix):
     """
     checks whether image positions are within the pixel image in units of arcsec
@@ -176,6 +188,7 @@ def coordInImage(x_coord, y_coord, numPix, deltapix):
     return x_coord, y_coord
 
 
+@export
 def re_size(image, factor=1):
     """
     re-sizes image with nx x ny to nx/factor x ny/factor
@@ -196,6 +209,7 @@ def re_size(image, factor=1):
         raise ValueError("scaling with factor %s is not possible with grid size %s, %s" %(f, nx, ny))
 
 
+@export
 def rebin_image(bin_size, image, wht_map, sigma_bkg, ra_coords, dec_coords, idex_mask):
     """
     rebins pixels, updates cutout image, wht_map, sigma_bkg, coordinates, PSF
@@ -220,6 +234,7 @@ def rebin_image(bin_size, image, wht_map, sigma_bkg, ra_coords, dec_coords, idex
     return image_resized, wht_map_resized, sigma_bkg_resized, ra_coords_resized, dec_coords_resized, idex_mask_resized
 
 
+@export
 def rebin_coord_transform(factor, x_at_radec_0, y_at_radec_0, Mpix2coord, Mcoord2pix):
     """
     adopt coordinate system and transformation between angular and pixel coordinates of a re-binned image
@@ -241,6 +256,7 @@ def rebin_coord_transform(factor, x_at_radec_0, y_at_radec_0, Mpix2coord, Mcoord
     return ra_at_xy_0_resized, dec_at_xy_0_resized, x_at_radec_0_resized, y_at_radec_0_resized, Mpix2coord_resized, Mcoord2pix_resized
 
 
+@export
 def stack_images(image_list, wht_list, sigma_list):
     """
     stacks images and saves new image as a fits file
@@ -260,6 +276,7 @@ def stack_images(image_list, wht_list, sigma_list):
     return image_stacked, wht_stacked, np.sqrt(sigma_stacked)
 
 
+@export
 def cut_edges(image, numPix):
     """
     cuts out the edges of a 2d image and returns re-sized image to numPix
@@ -285,6 +302,7 @@ def cut_edges(image, numPix):
     return copy.deepcopy(resized)
 
 
+@export
 def radial_profile(data, center=[0, 0]):
     """
     computes radial profile
@@ -303,6 +321,7 @@ def radial_profile(data, center=[0, 0]):
     return radialprofile
 
 
+@export
 def gradient_map(image):
     """
     computes gradients of images with the sobel transform

--- a/lenstronomy/Util/kernel_util.py
+++ b/lenstronomy/Util/kernel_util.py
@@ -9,7 +9,11 @@ import lenstronomy.Util.image_util as image_util
 from lenstronomy.LightModel.Profiles.gaussian import Gaussian
 import lenstronomy.Util.multi_gauss_expansion as mge
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def de_shift_kernel(kernel, shift_x, shift_y, iterations=20, fractional_step_size=1):
     """
     de-shifts a shifted kernel to the center of a pixel. This is performed iteratively.
@@ -44,6 +48,7 @@ def de_shift_kernel(kernel, shift_x, shift_y, iterations=20, fractional_step_siz
     return kernel_new[1:-1, 1:-1]
 
 
+@export
 def center_kernel(kernel, iterations=20):
     """
     given a kernel that might not be perfectly centered, this routine computes its light weighted center and then
@@ -67,6 +72,7 @@ def center_kernel(kernel, iterations=20):
     return kernel_norm(kernel_centered)
 
 
+@export
 def kernel_norm(kernel):
     """
 
@@ -78,6 +84,7 @@ def kernel_norm(kernel):
     return kernel
 
 
+@export
 def subgrid_kernel(kernel, subgrid_res, odd=False, num_iter=100):
     """
     creates a higher resolution kernel with subgrid resolution as an interpolation of the original kernel in an
@@ -138,6 +145,7 @@ def subgrid_kernel(kernel, subgrid_res, odd=False, num_iter=100):
     return kernel_norm(kernel_subgrid - delta_kernel_sub)
 
 
+@export
 def averaging_even_kernel(kernel_high_res, subgrid_res):
     """
     makes a lower resolution kernel based on the kernel_high_res (odd numbers) and the subgrid_res (even number), both
@@ -184,6 +192,7 @@ def averaging_even_kernel(kernel_high_res, subgrid_res):
     return kernel_low_res
 
 
+@export
 def kernel_pixelsize_change(kernel, deltaPix_in, deltaPix_out):
     """
     change the pixel size of a given kernel
@@ -203,6 +212,7 @@ def kernel_pixelsize_change(kernel, deltaPix_in, deltaPix_out):
     return kernel_out
 
 
+@export
 def cut_psf(psf_data, psf_size):
     """
     cut the psf properly
@@ -215,6 +225,7 @@ def cut_psf(psf_data, psf_size):
     return kernel
 
 
+@export
 def pixel_kernel(point_source_kernel, subgrid_res=7):
     """
     converts a pixelised kernel of a point source to a kernel representing a uniform extended pixel
@@ -235,6 +246,7 @@ def pixel_kernel(point_source_kernel, subgrid_res=7):
     return kernel_norm(kernel_pixel)
 
 
+@export
 def kernel_average_pixel(kernel_super, supersampling_factor):
     """
     computes the effective convolution kernel assuming a uniform surface brightness on the scale of a pixel
@@ -266,6 +278,7 @@ def kernel_average_pixel(kernel_super, supersampling_factor):
     return kernel_pixel * kernel_sum
 
 
+@export
 def kernel_gaussian(kernel_numPix, deltaPix, fwhm):
     sigma = util.fwhm2sigma(fwhm)
     #if kernel_numPix % 2 == 0:
@@ -278,6 +291,7 @@ def kernel_gaussian(kernel_numPix, deltaPix, fwhm):
     return kernel
 
 
+@export
 def split_kernel(kernel_super, supersampling_kernel_size, supersampling_factor, normalized=True):
     """
     pixel kernel and subsampling kernel such that the convolution of both applied on an image can be
@@ -318,6 +332,7 @@ def split_kernel(kernel_super, supersampling_kernel_size, supersampling_factor, 
     return kernel_hole_resized, kernel_subgrid_cut
 
 
+@export
 def degrade_kernel(kernel_super, degrading_factor):
     """
 
@@ -343,6 +358,7 @@ def degrade_kernel(kernel_super, degrading_factor):
     return kernel_low_res
 
 
+@export
 def cutout_source(x_pos, y_pos, image, kernelsize, shift=True):
     """
     cuts out point source (e.g. PSF estimate) out of image and shift it to the center of a pixel
@@ -383,6 +399,7 @@ def cutout_source(x_pos, y_pos, image, kernelsize, shift=True):
     return kernel_final
 
 
+@export
 def fwhm_kernel(kernel):
     """
 
@@ -404,6 +421,7 @@ def fwhm_kernel(kernel):
     raise ValueError('The kernel did not drop to half the max value - fwhm not determined!')
 
 
+@export
 def estimate_amp(data, x_pos, y_pos, psf_kernel):
     """
     estimates the amplitude of a point source located at x_pos, y_pos
@@ -429,6 +447,7 @@ def estimate_amp(data, x_pos, y_pos, psf_kernel):
     return amp_estimated
 
 
+@export
 def mge_kernel(kernel, order=5):
     """
     azimutal Multi-Gaussian expansion of a pixelized kernel

--- a/lenstronomy/Util/mask_util.py
+++ b/lenstronomy/Util/mask_util.py
@@ -1,7 +1,11 @@
 import numpy as np
 import lenstronomy.Util.util as util
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def mask_center_2d(center_x, center_y, r, x_grid, y_grid):
     """
 
@@ -21,6 +25,7 @@ def mask_center_2d(center_x, center_y, r, x_grid, y_grid):
     return mask
 
 
+@export
 def mask_sphere(x, y, center_x, center_y, r):
     """
 
@@ -38,6 +43,7 @@ def mask_sphere(x, y, center_x, center_y, r):
     return mask
 
 
+@export
 def mask_ellipse(x, y, center_x, center_y, a, b, angle):
     """
 
@@ -60,6 +66,7 @@ def mask_ellipse(x, y, center_x, center_y, a, b, angle):
     return mask
 
 
+@export
 def mask_half_moon(x, y, center_x, center_y, r_in, r_out, phi0=0, delta_phi=2*np.pi):
     """
 

--- a/lenstronomy/Util/multi_gauss_expansion.py
+++ b/lenstronomy/Util/multi_gauss_expansion.py
@@ -10,6 +10,11 @@ from lenstronomy.LightModel.Profiles.gaussian import Gaussian
 gaussian_func = Gaussian()
 
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
+
+@export
 def gaussian(R, sigma, amp):
     """
 
@@ -22,6 +27,7 @@ def gaussian(R, sigma, amp):
     return c * np.exp(-(R/float(sigma))**2/2.)
 
 
+@export
 def mge_1d(r_array, flux_r, N=20, linspace=False):
     """
 
@@ -44,6 +50,7 @@ def mge_1d(r_array, flux_r, N=20, linspace=False):
     return amplitudes, sigmas, norm
 
 
+@export
 def _mge_1d(r_array, flux_r, N=20, linspace=False):
     """
 
@@ -65,6 +72,7 @@ def _mge_1d(r_array, flux_r, N=20, linspace=False):
     return amplitudes, sigmas, norm
 
 
+@export
 def de_projection_3d(amplitudes, sigmas):
     """
     de-projects a gaussian (or list of multiple Gaussians from a 2d projected to a 3d profile)

--- a/lenstronomy/Util/numba_util.py
+++ b/lenstronomy/Util/numba_util.py
@@ -13,6 +13,8 @@ nopython = True
 cache = True
 parallel = False
 
+__all__ = ['jit']
+
 
 def jit(nopython=nopython, cache=cache, parallel=parallel):
     def wrapper(func):

--- a/lenstronomy/Util/package_util.py
+++ b/lenstronomy/Util/package_util.py
@@ -1,0 +1,83 @@
+
+def exporter(export_self=False):
+    """Export utility, modified from https://stackoverflow.com/a/41895194
+    Returns export decorator, __all__ list
+    """
+    all_ = []
+    if export_self:
+        all_.append('exporter')
+
+    def decorator(obj):
+        all_.append(obj.__name__)
+        return obj
+
+    return decorator, all_
+
+
+export, __all__ = exporter(export_self=True)
+
+
+@export
+def laconic():
+    """Activate laconic / super-shortcut mode.
+
+    Usage:
+        import lenstronomy as ls
+        ls.laconic()
+
+        lens_model = ls.LensModel(...)
+        source_model = ls.LightModel(...)
+        image_model = ls.ImageModel(...)
+    """
+    short(_laconic=True)
+
+
+@export
+def short(_laconic=False):
+    """Activate shortcut mode.
+
+    Usage:
+        import lenstronomy as ls
+        ls.short()
+
+        lens_model = ls.LensModel.lens_model.LensModel(...)
+        source_model = ls.LightModel.light_model.LightModel(...)
+        image_model = ls.ImSim.image_model.ImageModel(...)
+    """
+    import pkgutil
+    import lenstronomy
+
+    to_add = dict()
+    all_modules = dict()
+
+    for loader, module_name, is_pkg in pkgutil.walk_packages(lenstronomy.__path__):
+        # Load the module
+        module = all_modules[module_name] = \
+            loader.find_module(module_name).load_module(module_name)
+
+        if '.' in module_name:
+            # Submodule, e.g. Data.psf
+            # Monkeypatch the parent module to make it accessible
+            fragments = module_name.split('.')
+            parent_module_name, child_name = '.'.join(fragments[:-1]), fragments[-1]
+            setattr(all_modules[parent_module_name], child_name, module)
+        else:
+            # Top-level module, e.g. Data: add as lenstronomy attribute
+            to_add[module_name] = module
+
+        if _laconic:
+            # If the module defines an __all__, load its symbols as well.
+            # (unlike import *, we do not just load everything if __all__ is missing)
+            if hasattr(module, '__all__'):
+                for symbol in module.__all__:
+                    if symbol in to_add:
+                        # Name clash! Do not add either this symbol
+                        # or the one it clashed with.
+                        del to_add[symbol]
+                    else:
+                        to_add[symbol] = getattr(module, symbol)
+
+    # Make symbols accessible under lenstronomy.[x]
+    for key, value in to_add.items():
+        setattr(lenstronomy, key, value)
+    lenstronomy.__all__ = to_add.keys()

--- a/lenstronomy/Util/package_util.py
+++ b/lenstronomy/Util/package_util.py
@@ -1,3 +1,5 @@
+import types
+
 
 def exporter(export_self=False):
     """Export utility, modified from https://stackoverflow.com/a/41895194
@@ -70,12 +72,18 @@ def short(_laconic=False):
             # (unlike import *, we do not just load everything if __all__ is missing)
             if hasattr(module, '__all__'):
                 for symbol in module.__all__:
-                    if symbol in to_add:
-                        # Name clash! Do not add either this symbol
+                    symbol_name = symbol
+                    if isinstance(to_add.get(symbol), types.ModuleType):
+                        # Key class clashing with module name
+                        # (Cosmo, LensModel, LightModel, PointSource)
+                        # Try to add the symbol as LensModel_:
+                        symbol_name = symbol + '_'
+                    if symbol_name in to_add:
+                        # Name clash! Do not add the symbol
                         # or the one it clashed with.
-                        del to_add[symbol]
+                        del to_add[symbol_name]
                     else:
-                        to_add[symbol] = getattr(module, symbol)
+                        to_add[symbol_name] = getattr(module, symbol)
 
     # Make symbols accessible under lenstronomy.[x]
     for key, value in to_add.items():

--- a/lenstronomy/Util/param_util.py
+++ b/lenstronomy/Util/param_util.py
@@ -1,6 +1,10 @@
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def cart2polar(x, y, center_x=0, center_y=0):
     """
     transforms cartesian coords [x,y] into polar coords [r,phi] in the frame of the lense center
@@ -22,6 +26,7 @@ def cart2polar(x, y, center_x=0, center_y=0):
     return r, phi
 
 
+@export
 def polar2cart(r, phi, center):
     """
     transforms polar coords [r,phi] into cartesian coords [x,y] in the frame of the lense center
@@ -38,6 +43,7 @@ def polar2cart(r, phi, center):
     return x - center[0], y - center[1]
 
 
+@export
 def shear_polar2cartesian(phi, gamma):
     """
 
@@ -50,6 +56,7 @@ def shear_polar2cartesian(phi, gamma):
     return gamma1, gamma2
 
 
+@export
 def shear_cartesian2polar(gamma1, gamma2):
     """
     :param gamma1: cartesian shear component
@@ -61,6 +68,7 @@ def shear_cartesian2polar(gamma1, gamma2):
     return phi, gamma
 
 
+@export
 def phi_q2_ellipticity(phi, q):
     """
     transforms orientation angle and axis ratio into complex ellipticity moduli e1, e2
@@ -74,6 +82,7 @@ def phi_q2_ellipticity(phi, q):
     return e1, e2
 
 
+@export
 def ellipticity2phi_q(e1, e2):
     """
     transforms complex ellipticity moduli in orientation angle and axis ratio
@@ -89,6 +98,7 @@ def ellipticity2phi_q(e1, e2):
     return phi, q
 
 
+@export
 def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     """
     maps the coordinates x, y with eccentricities e1 e2 into a new elliptical coordinate system
@@ -114,6 +124,7 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     return xt1 * np.sqrt(q), xt2 / np.sqrt(q)
 
 
+@export
 def transform_e1e2_square_average(x, y, e1, e2, center_x, center_y):
     """
     maps the coordinates x, y with eccentricities e1 e2 into a new elliptical coordinate system

--- a/lenstronomy/Util/prob_density.py
+++ b/lenstronomy/Util/prob_density.py
@@ -3,7 +3,11 @@ __author__ = 'sibirrer'
 from scipy import stats
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 class SkewGaussian(object):
     """
     class for the Skew Gaussian distribution
@@ -92,6 +96,7 @@ class SkewGaussian(object):
         return e, w, a
 
 
+@export
 class KDE1D(object):
     """
     class that allows to compute likelihoods based on a 1-d posterior sample
@@ -115,6 +120,7 @@ class KDE1D(object):
         return dens
 
 
+@export
 def compute_lower_upper_errors(sample, num_sigma=1):
     """
     computes the upper and lower sigma from the median value.

--- a/lenstronomy/Util/sampling_util.py
+++ b/lenstronomy/Util/sampling_util.py
@@ -3,6 +3,9 @@ __author__ = 'aymgal'
 import numpy as np
 from scipy import special
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
+
 
 # transform the unit hypercube to pysical parameters for (nested) sampling
 
@@ -10,6 +13,7 @@ from scipy import special
 SQRT2 = np.sqrt(2)
 
 
+@export
 def unit2gaussian(x, mu, sigma):
     """
     mapping from uniform distribution on unit hypercube
@@ -21,6 +25,7 @@ def unit2gaussian(x, mu, sigma):
     return mu + SQRT2 * sigma * special.erfinv(2*x - 1)
 
 
+@export
 def unit2uniform(x, vmin, vmax):
     """
     mapping from uniform distribution on parameter space 
@@ -29,6 +34,7 @@ def unit2uniform(x, vmin, vmax):
     return vmin + (vmax - vmin) * x
 
 
+@export
 def uniform2unit(theta, vmin, vmax):
     """
     mapping from uniform distribution on unit hypercube
@@ -37,6 +43,7 @@ def uniform2unit(theta, vmin, vmax):
     return (theta - vmin) / (vmax - vmin)
 
 
+@export
 def cube2args_uniform(cube, lowers, uppers, num_dims, copy=False):
     """
     mapping from uniform distribution on unit hypercube 'cube'
@@ -59,6 +66,7 @@ def cube2args_uniform(cube, lowers, uppers, num_dims, copy=False):
     return cube
 
 
+@export
 def cube2args_gaussian(cube, lowers, uppers, means, sigmas, num_dims, copy=False):
     """
     mapping from uniform distribution on unit hypercube 'cube'
@@ -87,6 +95,7 @@ def cube2args_gaussian(cube, lowers, uppers, means, sigmas, num_dims, copy=False
     return cube
 
 
+@export
 def scale_limits(lowers, uppers, scale):
     if not isinstance(lowers, np.ndarray):
         lowers = np.asarray(lowers)
@@ -98,6 +107,7 @@ def scale_limits(lowers, uppers, scale):
     return lowers_scaled, uppers_scaled
 
 
+@export
 def sample_ball(p0, std, size=1, dist='uniform'):
     """
     Produce a ball of walkers around an initial parameter value.

--- a/lenstronomy/Util/simulation_util.py
+++ b/lenstronomy/Util/simulation_util.py
@@ -3,7 +3,11 @@ import lenstronomy.Util.image_util as image_util
 
 import numpy as np
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def data_configure_simple(numPix, deltaPix, exposure_time=None, background_rms=None, center_ra=0, center_dec=0,
                           inverse=False):
     """
@@ -33,6 +37,7 @@ def data_configure_simple(numPix, deltaPix, exposure_time=None, background_rms=N
     return kwargs_data
 
 
+@export
 def simulate_simple(image_model_class, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
                     no_noise=False, source_add=True, lens_light_add=True, point_source_add=True):
     """

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -8,7 +8,11 @@ import numpy as np
 import mpmath
 import itertools
 
+from lenstronomy.Util.package_util import exporter
+export, __all__ = exporter()
 
+
+@export
 def merge_dicts(*dict_args):
     """
     Given any number of dicts, shallow copy and merge into a new dict,
@@ -20,6 +24,7 @@ def merge_dicts(*dict_args):
     return result
 
 
+@export
 def approx_theta_E(ximg,yimg):
 
     dis = []
@@ -42,6 +47,7 @@ def approx_theta_E(ximg,yimg):
     return 0.5*(dr_greatest*dr_second)**0.5
 
 
+@export
 def sort_image_index(ximg,yimg,xref,yref):
 
     """
@@ -74,6 +80,7 @@ def sort_image_index(ximg,yimg,xref,yref):
     return min_indexes
 
 
+@export
 def rotate(xcoords, ycoords, angle):
     """
 
@@ -85,6 +92,7 @@ def rotate(xcoords, ycoords, angle):
     return xcoords*np.cos(angle)+ycoords*np.sin(angle), -xcoords*np.sin(angle)+ycoords*np.cos(angle)
 
 
+@export
 def map_coord2pix(ra, dec, x_0, y_0, M):
     """
     this routines performs a linear transformation between two coordinate systems. Mainly used to transform angular
@@ -100,6 +108,7 @@ def map_coord2pix(ra, dec, x_0, y_0, M):
     return x + x_0, y + y_0
 
 
+@export
 def array2image(array, nx=0, ny=0):
     """
     returns the information contained in a 1d array into an n*n 2d array (only works when lenght of array is n**2)
@@ -118,6 +127,7 @@ def array2image(array, nx=0, ny=0):
     return image
 
 
+@export
 def image2array(image):
     """
     returns the information contained in a 2d array into an n*n 1d array
@@ -132,6 +142,7 @@ def image2array(image):
     return imgh
 
 
+@export
 def array2cube(array, n_1, n_23):
     """
     returns the information contained in a 1d array of shape (n_1*n_23*n_23) into 3d array with shape (n_1, sqrt(n_23), sqrt(n_23))
@@ -153,6 +164,7 @@ def array2cube(array, n_1, n_23):
     return cube
 
 
+@export
 def cube2array(cube):
     """
     returns the information contained in a 3d array of shape (n_1, n_2, n_3) into 1d array with shape (n_1*n_2*n_3)
@@ -166,6 +178,7 @@ def cube2array(cube):
     return array
     
 
+@export
 def make_grid(numPix, deltapix, subgrid_res=1, left_lower=False):
     """
     creates pixel grid (in 1d arrays of x- and y- positions)
@@ -190,6 +203,7 @@ def make_grid(numPix, deltapix, subgrid_res=1, left_lower=False):
     return x_grid - shift, y_grid - shift
 
 
+@export
 def make_grid_transformed(numPix, Mpix2Angle):
     """
     returns grid with linear transformation (deltaPix and rotation)
@@ -202,6 +216,7 @@ def make_grid_transformed(numPix, Mpix2Angle):
     return ra_grid, dec_grid
 
 
+@export
 def make_grid_with_coordtransform(numPix, deltapix, subgrid_res=1, center_ra=0, center_dec=0, left_lower=False, inverse=True):
     """
     same as make_grid routine, but returns the transformation matrix and shift between coordinates and pixel
@@ -241,6 +256,7 @@ def make_grid_with_coordtransform(numPix, deltapix, subgrid_res=1, center_ra=0, 
     return ra_grid, dec_grid, ra_at_xy_0, dec_at_xy_0, x_at_radec_0, y_at_radec_0, Mpix2coord, Mcoord2pix
 
 
+@export
 def grid_from_coordinate_transform(nx, ny, Mpix2coord, ra_at_xy_0, dec_at_xy_0):
     """
     return a grid in x and y coordinates that satisfy the coordinate system
@@ -263,6 +279,7 @@ def grid_from_coordinate_transform(nx, ny, Mpix2coord, ra_at_xy_0, dec_at_xy_0):
     return ra_grid, dec_grid
 
 
+@export
 def get_axes(x, y):
     """
     computes the axis x and y of a given 2d grid
@@ -280,6 +297,7 @@ def get_axes(x, y):
     return x_axes, y_axes
 
 
+@export
 def averaging(grid, numGrid, numPix):
     """
     resize 2d pixel grid with numGrid to numPix and averages over the pixels
@@ -295,6 +313,7 @@ def averaging(grid, numGrid, numPix):
     return small
 
 
+@export
 def displaceAbs(x, y, sourcePos_x, sourcePos_y):
     """
     calculates a grid of distances to the observer in angel
@@ -312,6 +331,7 @@ def displaceAbs(x, y, sourcePos_x, sourcePos_y):
     return absmapped
 
 
+@export
 def get_distance(x_mins, y_mins, x_true, y_true):
     """
 
@@ -338,6 +358,7 @@ def get_distance(x_mins, y_mins, x_true, y_true):
     return dist
 
 
+@export
 def compare_distance(x_mapped, y_mapped):
     """
 
@@ -354,6 +375,7 @@ def compare_distance(x_mapped, y_mapped):
     return X2
 
 
+@export
 def min_square_dist(x_1, y_1, x_2, y_2):
     """
     return minimum of quadratic distance of pairs (x1, y1) to pairs (x2, y2)
@@ -369,6 +391,7 @@ def min_square_dist(x_1, y_1, x_2, y_2):
     return dist
 
 
+@export
 def selectBest(array, criteria, numSelect, highest=True):
     """
 
@@ -392,6 +415,7 @@ def selectBest(array, criteria, numSelect, highest=True):
     return result[::-1]
 
 
+@export
 def select_best(array, criteria, num_select, highest=True):
     """
 
@@ -415,6 +439,7 @@ def select_best(array, criteria, num_select, highest=True):
     return array[indexes]
 
 
+@export
 def points_on_circle(radius, num_points):
     """
     returns a set of uniform points around a circle
@@ -428,6 +453,7 @@ def points_on_circle(radius, num_points):
     return x_coord, y_coord
 
 
+@export
 def neighborSelect(a, x, y):
     """
     #TODO replace by from scipy.signal import argrelextrema for speed up
@@ -485,6 +511,7 @@ def neighborSelect(a, x, y):
     return np.array(x_mins), np.array(y_mins), np.array(values)
 
 
+@export
 def fwhm2sigma(fwhm):
     """
 
@@ -495,6 +522,7 @@ def fwhm2sigma(fwhm):
     return sigma
 
 
+@export
 def sigma2fwhm(sigma):
     """
 
@@ -505,6 +533,7 @@ def sigma2fwhm(sigma):
     return fwhm
 
 
+@export
 def hyper2F2_array(a, b, c, d, x):
     """
 
@@ -525,6 +554,7 @@ def hyper2F2_array(a, b, c, d, x):
     return out
 
 
+@export
 def make_subgrid(ra_coord, dec_coord, subgrid_res=2):
     """
     return a grid with subgrid resolution
@@ -553,6 +583,7 @@ def make_subgrid(ra_coord, dec_coord, subgrid_res=2):
     return ra_coords_sub, dec_coords_sub
 
 
+@export
 def convert_bool_list(n, k=None):
     """
     returns a bool list of the length of the lens models

--- a/lenstronomy/Workflow/alignment_matching.py
+++ b/lenstronomy/Workflow/alignment_matching.py
@@ -6,6 +6,8 @@ from lenstronomy.Sampling.Pool.pool import choose_pool
 from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
 from lenstronomy.Sampling.Samplers.pso import ParticleSwarmOptimizer
 
+__all__ = ['AlignmentFitting', 'AlignmentLikelihood']
+
 
 class AlignmentFitting(object):
     """

--- a/lenstronomy/Workflow/fitting_sequence.py
+++ b/lenstronomy/Workflow/fitting_sequence.py
@@ -10,6 +10,8 @@ from lenstronomy.Sampling.Samplers.dynesty_sampler import DynestySampler
 import numpy as np
 import lenstronomy.Util.analysis_util as analysis_util
 
+__all__ = ['FittingSequence']
+
 
 class FittingSequence(object):
     """

--- a/lenstronomy/Workflow/multi_band_manager.py
+++ b/lenstronomy/Workflow/multi_band_manager.py
@@ -3,6 +3,8 @@ __author__ = 'sibirrer'
 from lenstronomy.Workflow.update_manager import UpdateManager
 import copy
 
+__all__ = ['MultiBandUpdateManager']
+
 
 class MultiBandUpdateManager(UpdateManager):
     """

--- a/lenstronomy/Workflow/psf_fitting.py
+++ b/lenstronomy/Workflow/psf_fitting.py
@@ -8,6 +8,8 @@ import numpy as np
 import copy
 import scipy.ndimage.interpolation as interp
 
+__all__ = ['PsfFitting']
+
 
 class PsfFitting(object):
     """

--- a/lenstronomy/Workflow/update_manager.py
+++ b/lenstronomy/Workflow/update_manager.py
@@ -1,6 +1,8 @@
 import copy
 from lenstronomy.Sampling.parameters import Param
 
+__all__ = ['UpdateManager']
+
 
 class UpdateManager(object):
     """

--- a/lenstronomy/__init__.py
+++ b/lenstronomy/__init__.py
@@ -2,3 +2,5 @@ __author__ = 'Simon Birrer'
 __email__ = 'sibirrer@gmail.com'
 __version__ = '1.6.0'
 __credits__ = 'ETH Zurich, UCLA, Stanford'
+
+from .Util.package_util import short, laconic

--- a/test/test_LensModel/test_Optimizer/test_multi_plane.py
+++ b/test/test_LensModel/test_Optimizer/test_multi_plane.py
@@ -1,4 +1,5 @@
 from lenstronomy.LensModel.Optimizer.optimizer import Optimizer, MultiPlaneLensing
+import numpy as np     # _is_ used, import * does not bring in np due to __all__
 import numpy.testing as npt
 from astropy.cosmology import FlatLambdaCDM
 import pytest

--- a/test/test_Util/test_package_util.py
+++ b/test/test_Util/test_package_util.py
@@ -1,0 +1,72 @@
+import types
+
+def _remove_cached_lenstronomy():
+    """Removes lenstronomy from the module cache,
+    if it was already imported.
+    This is needed to reset the short / laconic states.
+    """
+    import sys
+    if 'lenstronomy' in sys.modules:
+        del sys.modules['lenstronomy']
+
+
+def test_short():
+    _remove_cached_lenstronomy()
+    import lenstronomy as ls
+
+    # Without running .short(), nothing is changed:
+    assert not hasattr(ls, 'LensModel')
+
+    ls.short()
+
+    # We can access submodules as symbols...
+    assert hasattr(ls, 'LensModel')
+    assert isinstance(ls.LensModel, types.ModuleType)
+
+    # ... also recursively.
+    assert hasattr(ls.LensModel, 'lens_model')
+    assert isinstance(ls.LensModel.lens_model, types.ModuleType)
+
+    # Symbols inside the module are available
+    assert 'LensModel' in ls.LensModel.lens_model.__all__
+    assert hasattr(ls.LensModel.lens_model, 'LensModel')
+    assert isinstance(ls.LensModel.lens_model.LensModel, type)
+
+
+def test_laconic():
+    _remove_cached_lenstronomy()
+    import lenstronomy as ls
+
+    # Without running .laconic(), nothing is changed:
+    assert not hasattr(ls, 'LensModel')
+    assert not hasattr(ls, 'MultiBandImageReconstruction')
+
+    ls.laconic()
+
+    # We can access lenstronomy symbols directy
+    assert hasattr(ls, 'MultiBandImageReconstruction')
+    assert isinstance(ls.MultiBandImageReconstruction, type)
+
+    # Non-lenstronomy symbols are not accessible
+    assert not hasattr(ls, 'np')
+    assert not hasattr(ls, 'numpy')
+
+    # Clashing symbols are not accessible
+    assert not hasattr(ls, 'PSF')
+
+    # 'short' type access still works
+    assert hasattr(ls, 'Analysis')
+    assert isinstance(ls.Analysis, types.ModuleType)
+    assert hasattr(ls.Analysis, 'image_reconstruction')
+    assert isinstance(ls.Analysis.image_reconstruction, types.ModuleType)
+    assert hasattr(ls.Analysis.image_reconstruction,
+                   'MultiBandImageReconstruction')
+    assert isinstance(ls.Analysis.image_reconstruction.MultiBandImageReconstruction,
+                      type)
+
+    # Key classes clashing with submodule names are
+    # accessible with an extra underscore
+    assert hasattr(ls, 'LensModel')
+    assert isinstance(ls.LensModel, types.ModuleType)
+    assert hasattr(ls, 'LensModel_')
+    assert isinstance(ls.LensModel_, type)

--- a/test/test_Util/test_package_util.py
+++ b/test/test_Util/test_package_util.py
@@ -4,10 +4,6 @@ import types
 def test_short_and_laconic():
     import lenstronomy as ls
 
-    # Without running .short() or .laconic(), nothing is changed:
-    assert not hasattr(ls, 'LensModel')
-    assert not hasattr(ls, 'MultiBandImageReconstruction')
-
     ls.short()
 
     # We can access submodules as symbols...

--- a/test/test_Util/test_package_util.py
+++ b/test/test_Util/test_package_util.py
@@ -1,21 +1,12 @@
 import types
 
-def _remove_cached_lenstronomy():
-    """Removes lenstronomy from the module cache,
-    if it was already imported.
-    This is needed to reset the short / laconic states.
-    """
-    import sys
-    if 'lenstronomy' in sys.modules:
-        del sys.modules['lenstronomy']
 
-
-def test_short():
-    _remove_cached_lenstronomy()
+def test_short_and_laconic():
     import lenstronomy as ls
 
-    # Without running .short(), nothing is changed:
+    # Without running .short() or .laconic(), nothing is changed:
     assert not hasattr(ls, 'LensModel')
+    assert not hasattr(ls, 'MultiBandImageReconstruction')
 
     ls.short()
 
@@ -31,15 +22,6 @@ def test_short():
     assert 'LensModel' in ls.LensModel.lens_model.__all__
     assert hasattr(ls.LensModel.lens_model, 'LensModel')
     assert isinstance(ls.LensModel.lens_model.LensModel, type)
-
-
-def test_laconic():
-    _remove_cached_lenstronomy()
-    import lenstronomy as ls
-
-    # Without running .laconic(), nothing is changed:
-    assert not hasattr(ls, 'LensModel')
-    assert not hasattr(ls, 'MultiBandImageReconstruction')
 
     ls.laconic()
 


### PR DESCRIPTION
This is a proposal to add an optional shorter API to lenstronomy, activated through the new `lenstronomy.short()` function:
```python
import lenstronomy as ls
ls.short()

lens_model = ls.LensModel.lens_model.LensModel(...)
source_model = ls.LightModel.light_model.LightModel(...)
image_model = ls.ImSim.image_model.ImageModel(...)
...
```

After you do `ls.short()`, tab-activated autocomplete will also work in jupyter, e.g. after you type `ls.` in the example above.

For more convenience, at the risk of losing clarity, there is also laconic mode:
```python
import lenstronomy as ls
ls.laconic()

lens_model = ls.LensModel_(...)
source_model = ls.LightModel_(...)
image_model = ls.ImageModel(...)
```
The underscores after `LensModel` and `LightModel` are needed to distinguish the classes from modules of the same name. You can also use the 'short' convention (`ls.LensModel.lens_model.LensModel`) in laconic mode.

Code written for `short` also runs under `laconic`; code written using the classic import-everything-explicitly API works under both.

Motivation
----------------
Lenstronomy has many submodules. To use a function or class, you have to know where it is defined, then import it from there. This is super clean and explicit, but a bit inconvenient for new users -- was `make_grid` defined in `lenstronomy.Util.image_util` or `lenstronomy.Util.util`? It also leads to baroque import headers, e.g.

```python
from lenstronomy.LensModel.lens_model import LensModel
from lenstronomy.LightModel.light_model import LightModel
from lenstronomy.ImSim.image_model import ImageModel
import lenstronomy.Util.image_util as image_util
import lenstronomy.Util.util as util
from lenstronomy.Cosmo.lens_cosmo import LensCosmo
...
```

Other big python packages usually [import their own components in `__init__.py`](https://github.com/numpy/numpy/blob/master/numpy/__init__.py#L145), so you can write e.g. `np.asmatrix` without `from numpy.matrixlib.defmatrix import asmatrix`. 

We could do the same in lenstronomy, and maybe this PR is a stepping stone towards that. 

However, there might be a concern: `__init__.py` is loaded whenever anything from a package is imported. Perhaps someone is running lenstronomy without astropy (or some other dependency) installed, and is using only the parts of lenstronomy that do not import astropy. If we went the `__init__.py` route, lenstronomy would break for that user. This PR avoids that problem, at the cost of the extra `ls.short()` line.

If you're not worried about this, I'd be happy to change this PR to have short or laconic mode active by defaul, i.e. without the `ls.short()` call.


Details
---------
This adds:
  * `__all__` lists to lenstronomy files, listing the lenstronomy symbols defined in that module. This is a standard python package feature, useful even if you hate the short/laconic APIs. If a user does `from ... import *`, it ensures only symbols from `__all__` are exported into the user's namespace, and not local variables, numpy, os, etc. `__all__` can also be exploited by documentation generators and other tools.
    * For files with one function/class, the `__all__` is defined manually at the top of the file. For files with many functions/classes, an `@export` decorator is used. It's easier to remember to add `@export` to a function than to add its name to `__all__` far away at the top of a file.
  * The `shortcut` and `laconic` functions. These make the modules (shortcut) or just everything (laconic) available under lenstronomy's namespace, which is empty by default. The `__all__` lists are used to figure out which symbols to make accessible in laconic mode (so you don't have `ls.np`, `ls.os`, etc.).

Note:
  * The old import API still works fine. Nothing extra is loaded if you don't use short or laconic mode.
  * Symbols used twice in lenstronomy are skipped for laconic mode. You'll have to type out `ls.Data.psf.PSF` or `ls.GalKin.psf.PSF`; there is no ambiguous `ls.PSF`.
    * Most clashes are between lens and light models of the same name. Full list: ` PSF  Chameleon DoubleChameleon TripleChameleon Gaussian Hernquist Interpol NIE PJaffe PJaffe_Ellipse Sersic   ParticleSwarmOptimizer radial_profile`.
    * Four key classes clash with top-level modules (`Cosmo` `LensModel` `LightModel` and `PointSource`).  In laconic and short mode, `ls.LensModel` points to the module, and the class is accessible through its full path (`ls.LensModel.lens_model.LensModel`). In laconic mode, the class is also accessible through its name with an extra underscore (`ls.LensModel_`).

Footnotes
-------------

Also removed some unused imports:
  * Coordinates1D in Data.pixel_grid
  * param_util and mask_util in LensModel.lens_model_extensions
  * polar2cart in LensModel.Optimizer.penalities
  * numpy in LightModel.Profiles.profile_base
  * scipy.special in LensModel.Profile.sis
  
Minor remarks:
  * The loose multi-line string in GalKin.aperture would not be found by any auto documentation tool. Maybe you want to combine it with the Aperture class or __init__ docstring? There might have been other, similar occurrences.
  * In `GalKin.aperature_types`, I currently just `@export`'ed everything, but maybe you don't need the `shell_select`, `shell_ifu_select` etc. since these are accessible through the aperture type classes instead. You might want to fine-tune exports elsewhere too if the laconic API becomes popular in the future.