### PR TITLE
Fix multiband image reconstruction for all bands_compute options

### DIFF
--- a/lenstronomy/Analysis/image_reconstruction.py
+++ b/lenstronomy/Analysis/image_reconstruction.py
@@ -62,26 +62,22 @@ class MultiBandImageReconstruction(object):
                 print(logL * 2 / n_data, 'reduced X^2 of all evaluated imaging data combined.')
 
         self.model_band_list = []
-        self._index_list = []
-        index = 0
         for i in range(len(multi_band_list)):
             if bands_compute[i] is True:
                 if multi_band_type == 'joint-linear':
                     param_i = param
                     cov_param_i = cov_param
                 else:
-                    param_i = param[index]
-                    cov_param_i = cov_param[index]
+                    param_i = param[i]
+                    cov_param_i = cov_param[i]
 
-                model_band = ModelBand(multi_band_list, kwargs_model, model[index], error_map[index], cov_param_i,
+                model_band = ModelBand(multi_band_list, kwargs_model, model[i], error_map[i], cov_param_i,
                                        param_i, copy.deepcopy(kwargs_params),
                                        image_likelihood_mask_list=image_likelihood_mask_list, band_index=i,
                                        verbose=verbose)
                 self.model_band_list.append(model_band)
-                self._index_list.append(index)
             else:
-                self._index_list.append(-1)
-            index += 1
+                self.model_band_list.append(None)
 
     def band_setup(self, band_index=0):
         """
@@ -91,10 +87,9 @@ class MultiBandImageReconstruction(object):
         :param band_index: integer (>=0) of imaging band in order of multi_band_list input to this class
         :return: ImageModel() instance and keyword arguments of the model
         """
-        i = self._index_list[band_index]
-        if i == -1:
-            raise ValueError("band %s is not computed or out of range." % band_index)
-        i = int(i)
+        i = int(band_index)
+        if self.model_band_list[i] is None:
+            raise ValueError("band %s is not computed or out of range." % i)
         return self.model_band_list[i].image_model_class, self.model_band_list[i].kwargs_model
 
 

--- a/lenstronomy/ImSim/MultiBand/multi_linear.py
+++ b/lenstronomy/ImSim/MultiBand/multi_linear.py
@@ -63,10 +63,12 @@ class MultiLinear(MultiDataBase):
                                                                                                      kwargs_extinction,
                                                                                                      kwargs_special,
                                                                                                      inv_bool=inv_bool)
-                wls_list.append(wls_model)
-                error_map_list.append(error_map)
-                cov_param_list.append(cov_param)
-                param_list.append(param)
+            else:
+                wls_model, error_map, cov_param, param = None, None, None, None
+            wls_list.append(wls_model)
+            error_map_list.append(error_map)
+            cov_param_list.append(cov_param)
+            param_list.append(param)
         return wls_list, error_map_list, cov_param_list, param_list
 
     def likelihood_data_given_model(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,

--- a/test/test_Analysis/test_image_reconstruction.py
+++ b/test/test_Analysis/test_image_reconstruction.py
@@ -96,6 +96,15 @@ class TestMultiBandImageReconstruction(object):
         model = image_model.image(**kwargs_params)
         npt.assert_almost_equal(model, self.kwargs_data['image_data'], decimal=5)
 
+    def test_bands_compute(self):
+        multi_band_list = [[self.kwargs_data, self.kwargs_psf, self.kwargs_numerics]]*2
+        multi_band = MultiBandImageReconstruction(multi_band_list, self.kwargs_model, self.kwargs_params,
+                                                  kwargs_likelihood={'bands_compute': [False, True]},
+                                                  multi_band_type='multi-linear')
+        image_model, kwargs_params = multi_band.band_setup(band_index=1)
+        model = image_model.image(**kwargs_params)
+        npt.assert_almost_equal(model, self.kwargs_data['image_data'], decimal=5)
+
     def test_not_verbose(self):
         multi_band_list = [[self.kwargs_data, self.kwargs_psf, self.kwargs_numerics]]
         multi_band = MultiBandImageReconstruction(multi_band_list, self.kwargs_model, self.kwargs_params,


### PR DESCRIPTION
When `bands_compute` was e.g. `[False, True]` for a 2-bands setup, there were index issues because the `image_linear_solve` method does not always return lists with same length as the number of bands. The fix is that for bands that are not "computed", now a `None` is put in the list instead. It also allows to simplify the code in the constructor of `MultiBandImageReconstruction`.
Please ask if the `None` choice is not the most suitable.