### PR TITLE
Prevent copy of a possibly large array in memory

### DIFF
--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -273,20 +273,20 @@ class ImageLinearFit(ImageModel):
             image = source_light_response[i]
             image *= extinction
             image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
-            A[n, :] = self.image2array_masked(image)
+            A[n, :] = np.nan_to_num(self.image2array_masked(image), copy=False)
             n += 1
         # response of lens light profile
         for i in range(0, n_lens_light):
             image = lens_light_response[i]
             image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
-            A[n, :] = self.image2array_masked(image)
+            A[n, :] = np.nan_to_num(self.image2array_masked(image), copy=False)
             n += 1
         # response of point sources
         for i in range(0, n_points):
             image = self.ImageNumerics.point_source_rendering(ra_pos[i], dec_pos[i], amp[i])
-            A[n, :] = self.image2array_masked(image)
+            A[n, :] = np.nan_to_num(self.image2array_masked(image), copy=False)
             n += 1
-        return np.nan_to_num(A)
+        return A
 
     def update_linear_kwargs(self, param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps):
         """


### PR DESCRIPTION
For instance, when using a high number of shapelet basis functions to model a large number of data pixels, the `nan_to_num` function implicated the copy of a large array in memory. This PR intends to limit the number of array copies.