### PR TITLE
NFWParam class mass and redshift definition updates

### DIFF
--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -25,7 +25,7 @@ class LensCosmo(object):
         self.z_lens = z_lens
         self.z_source = z_source
         self.background = Background(cosmo=cosmo)
-        self.nfw_param = NFWParam()
+        self.nfw_param = NFWParam(cosmo=cosmo)
 
     def a_z(self, z):
         """
@@ -179,10 +179,10 @@ class LensCosmo(object):
         Rs = Rs_angle * const.arcsec * self.dd
         theta_scaled = alpha_Rs * self.sigma_crit * self.dd * const.arcsec
         rho0 = theta_scaled / (4 * Rs ** 2 * (1 + np.log(1. / 2.)))
-        rho0_com = rho0 / self.h**2 * self.a_z(self.z_lens)**3
-        c = self.nfw_param.c_rho0(rho0_com)
+        rho0_com = rho0 / self.h**2
+        c = self.nfw_param.c_rho0(rho0_com, self.z_lens)
         r200 = c * Rs
-        M200 = self.nfw_param.M_r200(r200 * self.h / self.a_z(self.z_lens)) / self.h
+        M200 = self.nfw_param.M_r200(r200 * self.h, self.z_lens) / self.h
         return rho0, Rs, c, r200, M200
 
     def nfw_physical2angle(self, M, c):
@@ -205,8 +205,8 @@ class LensCosmo(object):
         :param c: concentration
         :return:
         """
-        r200 = self.nfw_param.r200_M(M * self.h) / self.h * self.a_z(self.z_lens)  # physical radius r200
-        rho0 = self.nfw_param.rho0_c(c) * self.h**2 / self.a_z(self.z_lens)**3 # physical density in M_sun/Mpc**3
+        r200 = self.nfw_param.r200_M(M * self.h, self.z_lens) / self.h  # physical radius r200
+        rho0 = self.nfw_param.rho0_c(c, self.z_lens) * self.h**2  # physical density in M_sun/Mpc**3
         Rs = r200/c
         return rho0, Rs, r200
 
@@ -217,7 +217,7 @@ class LensCosmo(object):
         :param M: physical mass in M_sun
         :return: angle (in arc seconds) of the virial radius
         """
-        r200 = self.nfw_param.r200_M(M * self.h) / self.h * self.a_z(self.z_lens)  # physical radius r200
+        r200 = self.nfw_param.r200_M(M * self.h, self.z_lens) / self.h  # physical radius r200
         theta_r200 = r200 / self.dd / const.arcsec
         return theta_r200
 

--- a/lenstronomy/Cosmo/nfw_param.py
+++ b/lenstronomy/Cosmo/nfw_param.py
@@ -6,9 +6,9 @@ __all__ = ['NFWParam']
 class NFWParam(object):
     """
     class which contains a halo model parameters dependent on cosmology for NFW profile
-    All distances are given in comoving coordinates. Mass definitions are relative to 200 crit at z=0 (with co-moving scaling).
-    Thus, also mass-concentration relations are used to reflect this. Pay attention when using different mass definitions!
-    Reasoning: This class does not require a cosmology dependence.
+    All distances are given in physical units. Mass definitions are relative to 200 crit including redshift evolution.
+    The redshift evolution is cosmology dependent (dark energy).
+    The H0 dependence is propagated into the input and return units.
     """
 
     rhoc = 2.77536627e11  # critical density [h^2 M_sun Mpc^-3]
@@ -28,59 +28,66 @@ class NFWParam(object):
         """
 
         :param z: redshift
-        :return: scaled critical density as a function of redshift (attention, this is not rho_crit(z))
+        :return: critical density of the universe at redshift z in physical units [h^2 M_sun Mpc^-3]
         """
-        #return self.cosmo.critical_density(z).value
-        return self.rhoc*(1+z)**3
+        return self.rhoc * (self.cosmo.efunc(z)) ** 2
+        #return self.rhoc*(1+z)**3
 
-    def M200(self, Rs, rho0, c):
+    def M200(self, rs, rho0, c):
         """
         M(R_200) calculation for NFW profile
 
-        :param Rs: scale radius
-        :type Rs: float
+        :param rs: scale radius
+        :type rs: float
         :param rho0: density normalization (characteristic density)
         :type rho0: float
         :param c: concentration
         :type c: float [4,40]
         :return: M(R_200) density
         """
-        return 4*np.pi*rho0*Rs**3*(np.log(1.+c)-c/(1.+c))
+        return 4 * np.pi * rho0 * rs ** 3 * (np.log(1. + c) - c / (1. + c))
 
-    def r200_M(self, M):
+    def r200_M(self, M, z):
         """
-        computes the radius R_200 of a halo of mass M in comoving distances M/h
+        computes the radius R_200 crit of a halo of mass M in physical distances M/h
 
         :param M: halo mass in M_sun/h
         :type M: float or numpy array
-        :return: radius R_200 in comoving Mpc/h
+        :param z: redshift
+        :type z: float
+        :return: radius R_200 in physical Mpc/h
         """
-        return (3*M/(4*np.pi*self.rhoc*200))**(1./3.)
+        return (3*M/(4*np.pi*self.rhoc_z(z)*200))**(1./3.)
 
-    def M_r200(self, r200):
+    def M_r200(self, r200, z):
         """
 
-        :param r200: r200 in comoving Mpc/h
-        :return: M200 in M_sol/h
+        :param r200: r200 in physical Mpc/h
+        :param z: redshift
+        :return: M200 in M_sun/h
         """
-        return self.rhoc*200 * r200**3 * 4*np.pi/3.
+        return self.rhoc_z(z)*200 * r200**3 * 4*np.pi/3.
 
-    def rho0_c(self, c):
+    def rho0_c(self, c, z):
         """
         computes density normalization as a function of concentration parameter
-        :return: density normalization in h^2/Mpc^3 (comoving)
-        """
-        return 200./3*self.rhoc*c**3/(np.log(1.+c)-c/(1.+c))
 
-    def c_rho0(self, rho0):
+        :param c: concentration
+        :param z: redshift
+        :return: density normalization in h^2/Mpc^3 (physical)
         """
-        computes the concentration given a comoving overdensity rho0 (inverse of function rho0_c)
-        :param rho0: density normalization in h^2/Mpc^3 (comoving)
+        return 200./3*self.rhoc_z(z)*c**3/(np.log(1.+c)-c/(1.+c))
+
+    def c_rho0(self, rho0, z):
+        """
+        computes the concentration given density normalization rho_0 in h^2/Mpc^3 (physical) (inverse of function rho0_c)
+        :param rho0: density normalization in h^2/Mpc^3 (physical)
+        :param z: redshift
         :return: concentration parameter c
         """
         if not hasattr(self, '_c_rho0_interp'):
             c_array = np.linspace(0.1, 10, 100)
-            rho0_array = self.rho0_c(c_array)
+            rho0_array = self.rho0_c(c_array, z)
             from scipy import interpolate
             self._c_rho0_interp = interpolate.InterpolatedUnivariateSpline(rho0_array, c_array, w=None, bbox=[None, None], k=3)
         return self._c_rho0_interp(rho0)
@@ -105,14 +112,14 @@ class NFWParam(object):
 
     def nfw_Mz(self, M, z):
         """
-        returns all needed parameter (in comoving units modulo h) to draw the profile of the main halo
-        r200 in co-moving Mpc/h
-        rho_s in  h^2/Mpc^3 (co-moving)
-        Rs in Mpc/h co-moving
+        returns all needed parameter (in physical units modulo h) to draw the profile of the main halo
+        r200 in physical Mpc/h
+        rho_s in  h^2/Mpc^3 (physical)
+        Rs in Mpc/h physical
         c unit less
         """
         c = self.c_M_z(M, z)
-        r200 = self.r200_M(M)
-        rho0 = self.rho0_c(c)
+        r200 = self.r200_M(M, z)
+        rho0 = self.rho0_c(c, z)
         Rs = r200/c
         return r200, rho0, c, Rs

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,12 @@ nestcheck
 corner
 h5py
 scikit-image
+
 #schwimmbad==0.3.0
 -e git://github.com/adrn/schwimmbad.git@master#egg=schwimmbad
 multiprocess>=0.70.8
 #-e git://github.com/sibirrer/fastell4py.git#egg=fastell4py
 slitronomy==0.3.2
+
+# requirements for tests
+colossus

--- a/test/test_Cosmo/test_lens_cosmo.py
+++ b/test/test_Cosmo/test_lens_cosmo.py
@@ -88,6 +88,11 @@ class TestLensCosmo(object):
         fermat_pot_out = self.lensCosmo.time_delay2fermat_pot(dt_days)
         npt.assert_almost_equal(fermat_pot, fermat_pot_out, decimal=10)
 
+    def test_a_z(self):
+
+        a = self.lensCosmo.a_z(z=1)
+        npt.assert_almost_equal(a, 0.5)
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_Cosmo/test_nfw_param.py
+++ b/test/test_Cosmo/test_nfw_param.py
@@ -1,35 +1,37 @@
-__author__ = 'sibirrer'
+__author__ = 'sibirrer', 'gilmanda'
 
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 from lenstronomy.Cosmo.nfw_param import NFWParam
+from astropy.cosmology import FlatLambdaCDM
+
 
 class TestLensCosmo(object):
     """
     tests the UnitManager class routines
     """
     def setup(self):
-        z_L = 0.8
-        z_S = 3.0
-        from astropy.cosmology import FlatLambdaCDM
+
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
-        self.nfwParam = NFWParam()
+        self.nfwParam = NFWParam(cosmo=cosmo)
+        self.z = 0.5  # needed fixed redshift for the inversion function
 
     def test_rho0_c(self):
         c = 4
-        rho0 = self.nfwParam.rho0_c(c)
-        c_out = self.nfwParam.c_rho0(rho0)
+
+        rho0 = self.nfwParam.rho0_c(c, z=self.z)
+        c_out = self.nfwParam.c_rho0(rho0, z=self.z)
         npt.assert_almost_equal(c_out, c, decimal=3)
 
     def test_rhoc_z(self):
-        z = 1
+        z = 0
         rho0_z = self.nfwParam.rhoc_z(z=z)
-        npt.assert_almost_equal(self.nfwParam.rhoc *(1+z)**3, rho0_z)
+        npt.assert_almost_equal(self.nfwParam.rhoc * (1+z)**3, rho0_z)
 
     def test_M200(self):
-        M200 = self.nfwParam.M200(Rs=1, rho0=1, c=1)
+        M200 = self.nfwParam.M200(rs=1, rho0=1, c=1)
         npt.assert_almost_equal(M200, 2.4271590540348216, decimal=5)
 
     def test_profileMain(self):
@@ -38,13 +40,51 @@ class TestLensCosmo(object):
         r200, rho0, c, Rs = self.nfwParam.nfw_Mz(M, z)
 
         c_ = self.nfwParam.c_M_z(M, z)
-        r200_ = self.nfwParam.r200_M(M)
-        rho0_ = self.nfwParam.rho0_c(c)
+        r200_ = self.nfwParam.r200_M(M, z)
+        rho0_ = self.nfwParam.rho0_c(c, z)
         Rs_ = r200_ / c_
         npt.assert_almost_equal(c_, c, decimal=5)
         npt.assert_almost_equal(r200_, r200, decimal=5)
         npt.assert_almost_equal(rho0_, rho0, decimal=5)
         npt.assert_almost_equal(Rs_, Rs, decimal=5)
+
+    def test_against_colossus(self):
+        """
+        This test class asks to get the same parameters back as colossus: https://bdiemer.bitbucket.io/colossus/index.html
+        """
+        cosmo = FlatLambdaCDM(H0=70, Om0=0.285, Ob0=0.05)
+        nfw_param = NFWParam(cosmo=cosmo)
+
+        from colossus.cosmology import cosmology as cosmology_colossus
+        from colossus.halo.profile_nfw import NFWProfile
+        colossus_kwargs = {'H0': 70, 'Om0': 0.285, 'Ob0': 0.05, 'ns': 0.96, 'sigma8': 0.82}
+        colossus = cosmology_colossus.setCosmology('custom', colossus_kwargs)
+
+        m200 = 10 ** 8
+        c = 17.
+
+        zvals = np.linspace(0.0, 2, 50)
+        h = 0.7
+
+        for z in zvals:
+            nfw_colossus = NFWProfile(m200 * h, z, mdef='200c')
+            rhos_colossus, rs_colossus = nfw_colossus.fundamentalParameters(m200 * h, c, z, mdef='200c')
+            r200_colossus = rs_colossus * c
+
+            # according to colossus documentation the density is in physical units[M h^2/kpc^3] and distance [kpc/h]
+            rs_colossus *= h ** -1
+            rhos_colossus *= h ** 2
+
+
+            r200_lenstronomy = nfw_param.r200_M(m200 * h, z) / h  # physical radius r200
+            rs_lenstronomy = r200_lenstronomy / c
+            rhos_lenstronomy = nfw_param.rho0_c(c, z) * h ** 2  # physical density in M_sun/Mpc**3
+
+            # convert Mpc to kpc
+            rhos_lenstronomy *= 1000 ** -3
+            rs_lenstronomy *= 1000
+            npt.assert_almost_equal(rs_lenstronomy/rs_colossus, 1, decimal=3)
+            npt.assert_almost_equal(rhos_lenstronomy / rhos_colossus, 1, decimal=3)
 
 
 if __name__ == '__main__':

--- a/test/test_Cosmo/test_nfw_param.py
+++ b/test/test_Cosmo/test_nfw_param.py
@@ -35,7 +35,7 @@ class TestLensCosmo(object):
         npt.assert_almost_equal(M200, 2.4271590540348216, decimal=5)
 
     def test_profileMain(self):
-        M = 10**(13.5)
+        M = 10 ** 13.5
         z = 0.5
         r200, rho0, c, Rs = self.nfwParam.nfw_Mz(M, z)
 


### PR DESCRIPTION
Changes the NFWParam class mass definitions to reflect an evolving critical density of the universe in the mass definitions and concentrations (previously was using co-moving rho crit=z to do so)