### PR TITLE
Fix for non-square source images in Interpol LightModel

### DIFF
--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -67,7 +67,7 @@ class PSF(object):
     def kernel_point_source(self):
         if not hasattr(self, '_kernel_point_source'):
             if self.psf_type == 'GAUSSIAN':
-                kernel_numPix = self._truncation * self._fwhm / self._pixel_size
+                kernel_numPix = round(self._truncation * self._fwhm / self._pixel_size)
                 if kernel_numPix % 2 == 0:
                     kernel_numPix += 1
                 self._kernel_point_source = kernel_util.kernel_gaussian(kernel_numPix, self._pixel_size, self._fwhm)

--- a/lenstronomy/LightModel/Profiles/interpolation.py
+++ b/lenstronomy/LightModel/Profiles/interpolation.py
@@ -60,7 +60,7 @@ class Interpol(object):
             image_bounds[1:-1, 1:-1] = image
             x_grid = np.linspace(start=-(nx0 - 1) / 2, stop=(nx0 - 1) / 2, num=nx0)
             y_grid = np.linspace(start=-(ny0 - 1) / 2, stop=(ny0 - 1) / 2, num=ny0)
-            self._image_interp = scipy.interpolate.RectBivariateSpline(y_grid, x_grid, image_bounds, kx=1, ky=1, s=0)
+            self._image_interp = scipy.interpolate.RectBivariateSpline(x_grid, y_grid, image_bounds, kx=1, ky=1, s=0)
         return self._image_interp(y, x)
 
     def total_flux(self, image, scale, amp=1, center_x=0, center_y=0, phi_G=0):

--- a/lenstronomy/LightModel/Profiles/interpolation.py
+++ b/lenstronomy/LightModel/Profiles/interpolation.py
@@ -54,6 +54,9 @@ class Interpol(object):
 
     def image_interp(self, x, y, image):
         if not hasattr(self, '_image_interp'):
+            # Setup the interpolator.
+            # Note that 'x' and 'y' in this block only refer to first and second
+            # image array axes. Outside this block it is more complicated.
             nx, ny = np.shape(image)
             image_bounds = np.zeros((nx + 2, ny + 2))
             nx0, ny0 = nx + 2, ny + 2
@@ -61,6 +64,9 @@ class Interpol(object):
             x_grid = np.linspace(start=-(nx0 - 1) / 2, stop=(nx0 - 1) / 2, num=nx0)
             y_grid = np.linspace(start=-(ny0 - 1) / 2, stop=(ny0 - 1) / 2, num=ny0)
             self._image_interp = scipy.interpolate.RectBivariateSpline(x_grid, y_grid, image_bounds, kx=1, ky=1, s=0)
+
+        # y and x must be flipped in call to interpolator
+        # (try reversing, the unit tests will fail)
         return self._image_interp(y, x)
 
     def total_flux(self, image, scale, amp=1, center_x=0, center_y=0, phi_G=0):

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -111,7 +111,8 @@ def map_coord2pix(ra, dec, x_0, y_0, M):
 @export
 def array2image(array, nx=0, ny=0):
     """
-    returns the information contained in a 1d array into an n*n 2d array (only works when lenght of array is n**2)
+    returns the information contained in a 1d array into an n*n 2d array
+    (only works when length of array is n**2, or nx and ny are provided)
 
     :param array: image values
     :type array: array of size n**2
@@ -186,7 +187,7 @@ def make_grid(numPix, deltapix, subgrid_res=1, left_lower=False):
 
     :param numPix: number of pixels per axis
         Give an integers for a square grid, or a 2-length sequence
-        (first, second axis length) for a rectangular grid.
+        (first, second axis length) for a non-square grid.
     :param deltapix: pixel size
     :param subgrid_res: sub-pixel resolution (default=1)
     :return: x, y position information in two 1d arrays

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -191,14 +191,23 @@ def make_grid(numPix, deltapix, subgrid_res=1, left_lower=False):
     :param subgrid_res: sub-pixel resolution (default=1)
     :return: x, y position information in two 1d arrays
     """
-    if isinstance(numPix, (tuple, list, np.ndarray)):
-        numPix = np.asarray(numPix).astype(np.int)
-    else:
-        numPix = np.array([round(numPix), round(numPix)])
 
+    # Check numPix is an integer, or 2-sequence of integers
+    if isinstance(numPix, (tuple, list, np.ndarray)):
+        assert len(numPix) == 2
+        if any(x != round(x) for x in numPix):
+            raise ValueError("numPix contains non-integers: %s" % numPix)
+        numPix = np.asarray(numPix, dtype=np.int)
+    else:
+        if numPix != round(numPix):
+            raise ValueError("Attempt to specify non-int numPix: %s" % numPix)
+        numPix = np.array([numPix, numPix], dtype=np.int)
+
+    # Super-resolution sampling
     numPix_eff = (numPix*subgrid_res).astype(np.int)
     deltapix_eff = deltapix/float(subgrid_res)
 
+    # Compute unshifted grids.
     # X values change quickly, Y values are repeated many times
     x_grid = np.tile(np.arange(numPix_eff[0]), numPix_eff[1]) * deltapix_eff
     y_grid = np.repeat(np.arange(numPix_eff[1]), numPix_eff[0]) * deltapix_eff

--- a/test/test_LightModel/test_Profiles/test_interpolation.py
+++ b/test/test_LightModel/test_Profiles/test_interpolation.py
@@ -16,27 +16,30 @@ class TestInterpol(object):
 
         :return:
         """
-        x, y = util.make_grid(numPix=20, deltapix=1.)
-        gauss = Gaussian()
-        flux = gauss.function(x, y, amp=1., center_x=0., center_y=0., sigma=1.)
-        image = util.array2image(flux)
-        interp = Interpol()
-        kwargs_interp = {'image': image, 'scale': 1., 'phi_G': 0., 'center_x': 0., 'center_y': 0.}
-        output = interp.function(x, y, **kwargs_interp)
-        npt.assert_equal(output, flux)
+        for len_x, len_y in [(20, 20), (14, 20)]:
+            x, y = util.make_grid(numPix=(len_x, len_y), deltapix=1.)
+            gauss = Gaussian()
+            flux = gauss.function(x, y, amp=1., center_x=0., center_y=0., sigma=1.)
+            image = util.array2image(flux, nx=len_y, ny=len_x)
 
-        flux = gauss.function(x-1., y, amp=1., center_x=0., center_y=0., sigma=1.)
-        kwargs_interp = {'image': image, 'scale': 1., 'phi_G': 0., 'center_x': 1., 'center_y': 0.}
-        output = interp.function(x, y, **kwargs_interp)
-        npt.assert_almost_equal(output, flux, decimal=0)
+            interp = Interpol()
+            kwargs_interp = {'image': image, 'scale': 1., 'phi_G': 0., 'center_x': 0., 'center_y': 0.}
+            output = interp.function(x, y, **kwargs_interp)
 
-        flux = gauss.function(x - 1., y - 1., amp=1, center_x=0., center_y=0., sigma=1.)
-        kwargs_interp = {'image': image, 'scale': 1., 'phi_G': 0., 'center_x': 1., 'center_y': 1.}
-        output = interp.function(x, y, **kwargs_interp)
-        npt.assert_almost_equal(output, flux, decimal=0)
+            npt.assert_equal(output, flux)
 
-        out = interp.function(x=1000, y=0, **kwargs_interp)
-        assert out == 0
+            flux = gauss.function(x-1., y, amp=1., center_x=0., center_y=0., sigma=1.)
+            kwargs_interp = {'image': image, 'scale': 1., 'phi_G': 0., 'center_x': 1., 'center_y': 0.}
+            output = interp.function(x, y, **kwargs_interp)
+            npt.assert_almost_equal(output, flux, decimal=0)
+
+            flux = gauss.function(x - 1., y - 1., amp=1, center_x=0., center_y=0., sigma=1.)
+            kwargs_interp = {'image': image, 'scale': 1., 'phi_G': 0., 'center_x': 1., 'center_y': 1.}
+            output = interp.function(x, y, **kwargs_interp)
+            npt.assert_almost_equal(output, flux, decimal=0)
+
+            out = interp.function(x=1000, y=0, **kwargs_interp)
+            assert out == 0
 
     def test_delete_cache(self):
         x, y = util.make_grid(numPix=20, deltapix=1.)

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -38,7 +38,7 @@ class TestLightModel(object):
             {'amp': 1},  # 'UNIFORM'
             {'amp': 1., 'gamma': 2., 'e1': e1, 'e2': e2, 'center_x': 0, 'center_y': 0},  # 'POWER_LAW'
             {'amp': .001, 'e1': 0, 'e2': 1., 'center_x': 0, 'center_y': 0, 's_scale': 1.},  # 'NIE'
-            {'image': np.zeros((10, 10)), 'scale': 1, 'phi_G': 0, 'center_x': 0, 'center_y': 0},
+            {'image': np.zeros((20, 5)), 'scale': 1, 'phi_G': 0, 'center_x': 0, 'center_y': 0},
             {'amp': [1], 'n_max': 0, 'beta': 1, 'center_x': 0, 'center_y': 0},
             {'amp': 1, 'radius': 1., 'e1': 0, 'e2': 0.1, 'center_x': 0, 'center_y': 0}  # 'ELLIPSOID'
             ]
@@ -86,7 +86,7 @@ class TestLightModel(object):
                             'MULTI_GAUSSIAN_ELLIPSE']
         kwargs_list = [{'amp': 1, 'R_sersic': 0.5, 'n_sersic': 1, 'center_x': 0, 'center_y': 0},  # 'SERSIC'
                        {'amp': 1, 'R_sersic': 0.5, 'n_sersic': 1, 'e1': 0.1, 'e2': 0, 'center_x': 0, 'center_y': 0},  # 'SERSIC_ELLIPSE'
-                       {'image': np.ones((10, 10)), 'scale': 1, 'phi_G': 0, 'center_x': 0, 'center_y': 0},  # 'INTERPOL'
+                       {'image': np.ones((20, 5)), 'scale': 1, 'phi_G': 0, 'center_x': 0, 'center_y': 0},  # 'INTERPOL'
                        {'amp': 2, 'sigma': 2, 'center_x': 0, 'center_y': 0},  # 'GAUSSIAN'
                        {'amp': 2, 'sigma': 2, 'e1': 0.1, 'e2': 0, 'center_x': 0, 'center_y': 0},  # 'GAUSSIAN_ELLIPSE'
                        {'amp': [1,1], 'sigma': [2, 1], 'center_x': 0, 'center_y': 0},  # 'MULTI_GAUSSIAN'

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -60,15 +60,31 @@ def test_map_coord2pix():
 def test_make_grid():
     numPix = 11
     deltapix = 1.
+
     grid = util.make_grid(numPix, deltapix)
     assert grid[0][0] == -5
-    assert np.sum(grid[0]) == 0
+    assert np.sum(grid[0]) == 0.
+
     x_grid, y_grid = util.make_grid(numPix, deltapix, subgrid_res=2.)
-    print(np.sum(x_grid))
-    assert np.sum(x_grid) == 0
+    assert np.sum(x_grid) == 0.
     assert x_grid[0] == -5.25
 
     x_grid, y_grid = util.make_grid(numPix, deltapix, subgrid_res=1, left_lower=True)
+    assert x_grid[0] == 0.
+    assert y_grid[0] == 0.
+
+    # Similar tests for a non-rectangular grid
+
+    x_grid, y_grid = util.make_grid((numPix, numPix - 1), deltapix)
+    assert x_grid[0] == -5.
+    assert y_grid[0] == -4.5
+    assert np.sum(x_grid) == np.sum(y_grid) == 0
+
+    x_grid, y_grid = util.make_grid(numPix, deltapix, subgrid_res=2.)
+    assert np.sum(x_grid) == np.sum(y_grid) == 0
+    assert x_grid[0] == -5.25
+
+    x_grid, y_grid = util.make_grid(numPix, deltapix, left_lower=True)
     assert x_grid[0] == 0
     assert y_grid[0] == 0
 


### PR DESCRIPTION
I got an error trying to use the Interpol LightModel with a non-square image as the `image` kwarg: `ValueError: x dimension of z must have same number of elements as x`, from inside scipy's `RectBivariateSpline`.

The cause is at https://github.com/sibirrer/lenstronomy/blob/master/lenstronomy/LightModel/Profiles/interpolation.py#L63, where the `x_grid` and `y_grid` arguments are switched. The first argument to `RectBivariateSpline` has to match the first dimension in the image array, whether one calls it x or y. 

This:
  * changes Interpol's unit test to use a (20, 5) instead of a (10, 10) image, which should be a strictly harder test case;
  * switches x_grid and y_grid arguments in the line above. Without this fix, the new test fails.

This only specifies a valid gridsize to the interpolator, nothing is changed in the image handling. In particular, the x and y are still 'flipped' when calling the interpolator in the line directly below https://github.com/sibirrer/lenstronomy/blob/master/lenstronomy/LightModel/Profiles/interpolation.py#L64. Since it is not changed, I did not think about this or check if it is correct -- but I assume this 'flip' is intentional, to transpose between computer science and physics display conventions? 

Just let me know if I misunderstood something or if you'd prefer a different solution. 