### PR TITLE
Kin numerics dev

### DIFF
--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -231,7 +231,10 @@ class KinematicsAPI(object):
             main deflector potential
         :param theta_E: (optional float) estimate of the Einstein radius. If present, does not numerically compute this
          quantity in this routine numerically
+        :param gamma: local power-law slope at the Einstein radius (optional)
         :param kwargs_mge: keyword arguments that go into the MGE decomposition routine
+        :param analytic_kinematics: bool, if True, solves the Jeans equation analytically for the
+         power-law mass profile with Hernquist light profile
         :return: mass_profile_list, keyword argument list
         """
         if analytic_kinematics is True:
@@ -295,6 +298,8 @@ class KinematicsAPI(object):
         :param Hernquist_approx: boolean, if True replaces the actual light profile(s) with a Hernquist model with
          matched half-light radius.
         :param kwargs_mge: keyword arguments that go into the MGE decomposition routine
+        :param analytic_kinematics: bool, if True, solves the Jeans equation analytically for the
+         power-law mass profile with Hernquist light profile and adjust the settings accordingly
         :return: deflector type list, keyword arguments list
         """
         if analytic_kinematics is True:

--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -128,8 +128,10 @@ class KinematicsAPI(object):
         :param kwargs_anisotropy: stellar anisotropy keyword arguments
         :param r_eff: projected half-light radius of the stellar light associated with the deflector galaxy, optional,
          if set to None will be computed in this function with default settings that may not be accurate.
-        :param num_kin_sampling: int, number of draws from a kinematic prediction of a LOS
-        :param num_psf_sampling: int, number of displacements/render from a spectra to be displaced on the IFU
+        :param theta_E: circularized Einstein radius, optional, if not provided will either be computed in this
+         function with default settings or not required
+        :param gamma: power-law slope at the Einstein radius, optional
+        :param kappa_ext: external convergence
         :return: velocity dispersion [km/s]
         """
         galkin, kwargs_profile, kwargs_light = self.galkin_settings(kwargs_lens, kwargs_lens_light, r_eff=r_eff,

--- a/lenstronomy/GalKin/analytic_kinematics.py
+++ b/lenstronomy/GalKin/analytic_kinematics.py
@@ -138,7 +138,7 @@ class AnalyticKinematics(Anisotropy):
         # first term
         prefac1 = 4*np.pi * const.G * a**(-gamma) * rho0_r0_gamma / (3-gamma)
         prefac2 = r * (r + a)**3/(r**2 + r_ani**2)
-        #TODO check whether interpolation functions can speed this up
+        # TODO check whether interpolation functions can speed this up
         hyp1 = vel_util.hyp_2F1(a=2+gamma, b=gamma, c=3+gamma, z=1./(1+r/a))
         hyp2 = vel_util.hyp_2F1(a=3, b=gamma, c=1+gamma, z=-a/r)
         fac = r_ani**2/a**2 * hyp1 / ((2+gamma) * (r/a + 1)**(2+gamma)) + hyp2 / (gamma*(r/a)**gamma)

--- a/lenstronomy/GalKin/galkin_model.py
+++ b/lenstronomy/GalKin/galkin_model.py
@@ -77,7 +77,7 @@ class GalkinModel(object):
         :param r_eff: half-light radius in arc seconds
         :return: equation (10) >= 0 for physical interpretation
         """
-        dr = 0.01 # finite differential in radial direction
+        dr = 0.01  # finite differential in radial direction
         r_dr = r + dr
 
         sigmar2 = self.numerics.sigma_r2(r, kwargs_mass, kwargs_light, kwargs_anisotropy)

--- a/lenstronomy/GalKin/light_profile.py
+++ b/lenstronomy/GalKin/light_profile.py
@@ -10,7 +10,7 @@ class LightProfile(object):
     """
     class to deal with the light distribution
     """
-    def __init__(self, profile_list, interpol_grid_num=1000, max_interpolate=100, min_interpolate=0.001):
+    def __init__(self, profile_list, interpol_grid_num=2000, max_interpolate=1000, min_interpolate=0.001):
         """
 
         :param profile_list:
@@ -39,7 +39,8 @@ class LightProfile(object):
             r_array = np.logspace(np.log10(self._min_interpolate), np.log10(self._max_interpolate), self._interp_grid_num)
             light_3d_array = self.light_model.light_3d(r_array, kwargs_list)
             light_3d_array[light_3d_array < 10 ** (-100)] = 10 ** (-100)
-            f = interp1d(np.log(r_array), np.log(light_3d_array), fill_value="extrapolate")
+            f = interp1d(np.log(r_array), np.log(light_3d_array), fill_value=(np.log(light_3d_array[0]), -1000),
+                         bounds_error=False)  # "extrapolate"
             self._f_light_3d = f
         return np.exp(self._f_light_3d(np.log(r)))
 
@@ -50,16 +51,18 @@ class LightProfile(object):
         :param kwargs_list:
         :return:
         """
-        #TODO make sure averaging is done azimuthally
-        kwargs_list_copy = copy.deepcopy(kwargs_list)
-        kwargs_list_new = []
-        for kwargs in kwargs_list_copy:
-            if 'e1' in kwargs:
-                kwargs['e1'] = 0
-            if 'e2' in kwargs:
-                kwargs['e2'] = 0
-            kwargs_list_new.append({k: v for k, v in kwargs.items() if not k in ['center_x', 'center_y']})
-        return self.light_model.surface_brightness(R, 0, kwargs_list_new)
+        # TODO make sure averaging is done azimuthally
+        if not hasattr(self, '_kwargs_light_circularized'):
+            kwargs_list_copy = copy.deepcopy(kwargs_list)
+            kwargs_list_new = []
+            for kwargs in kwargs_list_copy:
+                if 'e1' in kwargs:
+                    kwargs['e1'] = 0
+                if 'e2' in kwargs:
+                    kwargs['e2'] = 0
+                kwargs_list_new.append({k: v for k, v in kwargs.items() if not k in ['center_x', 'center_y']})
+            self._kwargs_light_circularized = kwargs_list_new
+        return self.light_model.surface_brightness(R, 0, self._kwargs_light_circularized)
 
     def draw_light_2d_linear(self, kwargs_list, n=1, new_compute=False, r_eff=1.):
         """
@@ -87,8 +90,10 @@ class LightProfile(object):
     def draw_light_2d(self, kwargs_list, n=1, new_compute=False):
         """
         constructs the CDF and draws from it random realizations of projected radii R
-        :param kwargs_list:
-        :return:
+        :param kwargs_list: light model keyword argument list
+        :param n: int, number of draws per functino call
+        :param new_compute: re-computes the interpolated CDF
+        :return: realization of projected radius following the distribution of the light model
         """
         if not hasattr(self, '_light_cdf_log') or new_compute is True:
             r_array = np.logspace(np.log10(self._min_interpolate), np.log10(self._max_interpolate), self._interp_grid_num)
@@ -107,6 +112,31 @@ class LightProfile(object):
         r_log_draw = self._light_cdf_log(cdf_draw)
         return np.exp(r_log_draw)
 
+    def draw_light_3d(self, kwargs_list, n=1, new_compute=False):
+        """
+        constructs the CDF and draws from it random realizations of 3D radii r
+        :param kwargs_list: light model keyword argument list
+        :param n: int, number of draws per functino call
+        :param new_compute: re-computes the interpolated CDF
+        :return: realization of projected radius following the distribution of the light model
+        """
+        if not hasattr(self, '_light_3d_cdf_log') or new_compute is True:
+            r_array = np.logspace(np.log10(self._min_interpolate), np.log10(self._max_interpolate), self._interp_grid_num)
+            cum_sum = np.zeros_like(r_array)
+            sum = 0
+            for i, r in enumerate(r_array):
+                if i == 0:
+                    cum_sum[i] = 0
+                else:
+                    sum += self.light_3d(r, kwargs_list) * r * r**2  # 1x r for the log spacing and r**2 for the shell area
+                    cum_sum[i] = copy.deepcopy(sum)
+            cum_sum_norm = cum_sum/cum_sum[-1]
+            f = interp1d(cum_sum_norm, np.log(r_array))
+            self._light_3d_cdf_log = f
+        cdf_draw = np.random.uniform(0., 1, n)
+        r_log_draw = self._light_3d_cdf_log(cdf_draw)
+        return np.exp(r_log_draw)
+
     def delete_cache(self):
         """
         deletes cached interpolation function of the CDF for a specific light profile
@@ -119,3 +149,5 @@ class LightProfile(object):
             del self._light_cdf
         if hasattr(self, '_f_light_3d'):
             del self._f_light_3d
+        if hasattr(self, '_kwargs_light_circularized'):
+            del self._kwargs_light_circularized

--- a/lenstronomy/GalKin/velocity_util.py
+++ b/lenstronomy/GalKin/velocity_util.py
@@ -105,8 +105,11 @@ def project2d_random(r):
     :param r: 3d radius
     :return: R, x, y
     """
-    phi = np.random.uniform(0, 2*np.pi)
-    theta = np.random.uniform(0, np.pi)
+    size = len(np.atleast_1d(r))
+    if size == 1:
+        size = None
+    phi = np.random.uniform(0, 2*np.pi, size=size)
+    theta = np.random.uniform(0, np.pi, size=size)
     x = r * np.sin(theta) * np.cos(phi)
     y = r * np.sin(theta) * np.sin(phi)
     R = np.sqrt(x**2 + y**2)

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -134,9 +134,11 @@ class TestKinematicsAPI(object):
         np.random.seed(42)
         z_lens = 0.5
         z_source = 1.5
+        r_eff = 1.
+        theta_E = 1.
         kwargs_model = {'lens_model_list': ['SIS'], 'lens_light_model_list': ['HERNQUIST']}
-        kwargs_lens = [{'theta_E': 1, 'center_x': 0, 'center_y': 0}]
-        kwargs_lens_light = [{'amp': 1, 'Rs': 1, 'center_x': 0, 'center_y': 0}]
+        kwargs_lens = [{'theta_E': theta_E, 'center_x': 0, 'center_y': 0}]
+        kwargs_lens_light = [{'amp': 1, 'Rs': r_eff * 0.551, 'center_x': 0, 'center_y': 0}]
         kwargs_anisotropy = {'r_ani': 1}
         # settings
 
@@ -151,17 +153,17 @@ class TestKinematicsAPI(object):
         kin_api = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture, kwargs_seeing,
                                 anisotropy_model=anisotropy_model)
 
-        kwargs_numerics_galkin = {'interpol_grid_num': 500, 'log_integration': True,
-                                  'max_integrate': 10, 'min_integrate': 0.001}
+        kwargs_numerics_galkin = {'interpol_grid_num': 2000, 'log_integration': True,
+                                  'max_integrate': 1000, 'min_integrate': 0.0001}
         kin_api.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin, analytic_kinematics=True,
                                      Hernquist_approx=False, MGE_light=False, MGE_mass=False)
-        vel_disp_analytic = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy, r_eff=None,
-                                                        theta_E=None, gamma=None)
+        vel_disp_analytic = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy, r_eff=r_eff,
+                                                        theta_E=theta_E, gamma=2)
 
         kin_api.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin, analytic_kinematics=False,
                                              Hernquist_approx=False, MGE_light=False, MGE_mass=False)
         vel_disp_numerical = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy,
-                                                         r_eff=None, theta_E=None, gamma=None)
+                                                         r_eff=r_eff, theta_E=theta_E, gamma=2)
         npt.assert_almost_equal(vel_disp_numerical / vel_disp_analytic, 1, decimal=2)
 
         kin_api.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin, analytic_kinematics=False,

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -162,8 +162,8 @@ class TestKinematicsAPI(object):
 
         kin_api.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin, analytic_kinematics=False,
                                              Hernquist_approx=False, MGE_light=False, MGE_mass=False)
-        vel_disp_numerical = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy,
-                                                         r_eff=r_eff, theta_E=theta_E, gamma=2)
+        vel_disp_numerical = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy) #,
+                                                         # r_eff=r_eff, theta_E=theta_E, gamma=2)
         npt.assert_almost_equal(vel_disp_numerical / vel_disp_analytic, 1, decimal=2)
 
         kin_api.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin, analytic_kinematics=False,

--- a/test/test_GalKin/test_anisotropy.py
+++ b/test/test_GalKin/test_anisotropy.py
@@ -130,6 +130,13 @@ class TestAnisotropy(object):
         K_gom = gom.K(r, R, **kwargs_gom)
         K_om = om.K(r, R, **kwargs_om)
         npt.assert_almost_equal(K_gom, K_om, decimal=3)
+        assert hasattr(gom._model, '_f_12_interp')
+        assert hasattr(gom._model, '_f_32_interp')
+        gom.delete_anisotropy_cache()
+        if hasattr(gom._model, '_f_12_interp'):
+            assert False
+        if hasattr(gom._model, '_f_32_interp'):
+            assert False
 
         from lenstronomy.GalKin.anisotropy import GeneralizedOM
         gom_class = GeneralizedOM()

--- a/test/test_GalKin/test_galkin.py
+++ b/test/test_GalKin/test_galkin.py
@@ -63,6 +63,12 @@ class TestGalkin(object):
             npt.assert_almost_equal(log_I_R[i] / lin_I_R[i], 1, decimal=2)
 
     def test_log_vs_linear_integral(self):
+        """
+        here we test logarithmic vs linear integral in an end-to-end fashion.
+        We do not demand the highest level of precsions here!!!
+        We are using the luminosity-weighted velocitydispersion integration calculation in this test.
+        """
+
         # light profile
         light_profile_list = ['HERNQUIST']
         Rs = .5
@@ -88,9 +94,9 @@ class TestGalkin(object):
         psf_fwhm = 0.7  # Gaussian FWHM psf
         kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
         kwargs_numerics_log = {'interpol_grid_num': 500, 'log_integration': True,
-                           'max_integrate': 10}
+                           'max_integrate': 10, 'lum_weight_int_method': True}
         kwargs_numerics_linear = {'interpol_grid_num': 500, 'log_integration': False,
-                           'max_integrate': 10}
+                           'max_integrate': 10, 'lum_weight_int_method': True}
         kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': psf_fwhm}
         kwargs_model = {'mass_profile_list': mass_profile_list,
                         'light_profile_list': light_profile_list,

--- a/test/test_GalKin/test_light_profile.py
+++ b/test/test_GalKin/test_light_profile.py
@@ -75,6 +75,10 @@ class TestLightProfile(object):
         hist /= np.sum(hist)
         print(light2d / hist)
         npt.assert_almost_equal(light2d[5] / hist[5], 1, decimal=1)
+        assert hasattr(lightProfile, '_kwargs_light_circularized')
+        lightProfile.delete_cache()
+        if hasattr(lightProfile, '_kwargs_light_circularized'):
+            assert False
 
     def test_draw_light_3d(self):
         lightProfile = LightProfile(profile_list=['HERNQUIST'], min_interpolate=0.0001, max_interpolate=100.)

--- a/test/test_GalKin/test_light_profile.py
+++ b/test/test_GalKin/test_light_profile.py
@@ -7,6 +7,7 @@ import numpy as np
 from lenstronomy.GalKin.light_profile import LightProfile
 from lenstronomy.Analysis.light_profile import LightProfileAnalysis
 from lenstronomy.LightModel.light_model import LightModel
+from lenstronomy.GalKin import velocity_util
 
 
 class TestLightProfile(object):
@@ -32,7 +33,7 @@ class TestLightProfile(object):
 
     def test_draw_light_2d_linear(self):
         np.random.seed(41)
-        lightProfile = LightProfile(profile_list=['HERNQUIST'])
+        lightProfile = LightProfile(profile_list=['HERNQUIST'], interpol_grid_num=1000, max_interpolate=10, min_interpolate=0.01)
         kwargs_profile = [{'amp': 1., 'Rs': 0.8}]
         r_list = lightProfile.draw_light_2d_linear(kwargs_profile, n=100000)
         bins = np.linspace(0., 1, 20)
@@ -74,6 +75,30 @@ class TestLightProfile(object):
         hist /= np.sum(hist)
         print(light2d / hist)
         npt.assert_almost_equal(light2d[5] / hist[5], 1, decimal=1)
+
+    def test_draw_light_3d(self):
+        lightProfile = LightProfile(profile_list=['HERNQUIST'], min_interpolate=0.0001, max_interpolate=100.)
+        kwargs_profile = [{'amp': 1., 'Rs': 0.5}]
+        r_list = lightProfile.draw_light_3d(kwargs_profile, n=100000, new_compute=False)
+        print(r_list, 'r_list')
+        # project it
+        R, x, y = velocity_util.project2d_random(r_list)
+        # test with draw light 2d profile routine
+
+        bins = np.linspace(0.1, 1, 10)
+        hist, bins_hist = np.histogram(r_list, bins=bins, density=True)
+        bins_plot = (bins_hist[1:] + bins_hist[:-1]) / 2.
+        light3d = lightProfile.light_3d(r=bins_plot, kwargs_list=kwargs_profile)
+        light3d *= bins_plot **2
+        light3d /= np.sum(light3d)
+        hist /= np.sum(hist)
+        #import matplotlib.pyplot as plt
+        #plt.plot(bins_plot , light3d/light3d[5], label='3d reference')
+        #plt.plot(bins_plot, hist / hist[5], label='hist')
+        #plt.legend()
+        #plt.show()
+        print(light3d / hist)
+        npt.assert_almost_equal(light3d[5] / hist[5], 1, decimal=1)
 
     def test_ellipticity_in_profiles(self):
         np.random.seed(41)

--- a/test/test_GalKin/test_numeric_kinematics.py
+++ b/test/test_GalKin/test_numeric_kinematics.py
@@ -32,32 +32,32 @@ class TestMassProfile(object):
         :return:
         """
         light_profile_list = ['HERNQUIST']
-        r_eff = 1.5
+        r_eff = 0.5
         Rs = 0.551 * r_eff
         kwargs_light = [{'Rs': Rs, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
         # 0.551 *
         # mass profile
         mass_profile_list = ['SPP']
         theta_E = 1.2
-        gamma = 2.
+        gamma = 1.95
         kwargs_mass = [{'theta_E': theta_E, 'gamma': gamma}]  # Einstein radius (arcsec) and power-law slope
 
         # anisotropy profile
         anisotropy_type = 'OM'
-        r_ani = 2.
+        r_ani = 0.5
         kwargs_anisotropy = {'r_ani': r_ani}  # anisotropy radius [arcsec]
 
         kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
-        kwargs_numerics = {'interpol_grid_num': 500, 'log_integration': True,
-                               'max_integrate': 100}
+        kwargs_numerics = {'interpol_grid_num': 2000, 'log_integration': True,
+                               'max_integrate': 4000, 'min_integrate': 0.001}
 
         kwargs_model = {'mass_profile_list': mass_profile_list,
                         'light_profile_list': light_profile_list,
                         'anisotropy_model': anisotropy_type}
-        analytic_kin = AnalyticKinematics(kwargs_cosmo)
+        analytic_kin = AnalyticKinematics(kwargs_cosmo, **kwargs_numerics)
         numeric_kin = NumericKinematics(kwargs_model, kwargs_cosmo, **kwargs_numerics)
         rho0_r0_gamma = analytic_kin._rho0_r0_gamma(theta_E, gamma)
-        r_array = np.logspace(-2, 0.5, 10)
+        r_array = np.logspace(-2.9, 2.9, 100)
         sigma_r_analytic_array = []
         sigma_r_num_array = []
         for r in r_array:
@@ -67,12 +67,47 @@ class TestMassProfile(object):
             sigma_r_num = np.sqrt(sigma_r2_num) / 1000
             sigma_r_num_array.append(sigma_r_num)
             sigma_r_analytic_array.append(sigma_r_analytic)
-        #import matplotlib.pyplot as plt
-        #plt.semilogx(r_array, np.array(sigma_r_analytic_array)/np.array(sigma_r_num_array), label='analytic')
-        #plt.semilogx(r_array, sigma_r_num_array, label='numeric')
-        #plt.legend()
-        #plt.show()
-        npt.assert_almost_equal(sigma_r_num_array, sigma_r_analytic_array, decimal=-1)
+
+        npt.assert_almost_equal(sigma_r_num_array, sigma_r_analytic_array, decimal=-2)
+        npt.assert_almost_equal(np.array(sigma_r_num_array) / np.array(sigma_r_analytic_array), 1, decimal=-2)
+        print(np.array(sigma_r_num_array) / np.array(sigma_r_analytic_array))
+
+    def test_sigma_s2(self):
+        """
+        test LOS projected velocity dispersion at 3d ratios (numerical Jeans equation solution vs analytic one)
+        """
+        light_profile_list = ['HERNQUIST']
+        r_eff = 0.5
+        Rs = 0.551 * r_eff
+        kwargs_light = [{'Rs': Rs, 'amp': 1.}]  # effective half light radius (2d projected) in arcsec
+        # 0.551 *
+        # mass profile
+        mass_profile_list = ['SPP']
+        theta_E = 1.2
+        gamma = 1.95
+        kwargs_mass = [{'theta_E': theta_E, 'gamma': gamma}]  # Einstein radius (arcsec) and power-law slope
+
+        # anisotropy profile
+        anisotropy_type = 'OM'
+        r_ani = 0.5
+        kwargs_anisotropy = {'r_ani': r_ani}  # anisotropy radius [arcsec]
+
+        kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}
+        kwargs_numerics = {'interpol_grid_num': 2000, 'log_integration': True,
+                           'max_integrate': 4000, 'min_integrate': 0.001}
+
+        kwargs_model = {'mass_profile_list': mass_profile_list,
+                        'light_profile_list': light_profile_list,
+                        'anisotropy_model': anisotropy_type}
+        analytic_kin = AnalyticKinematics(kwargs_cosmo, **kwargs_numerics)
+        numeric_kin = NumericKinematics(kwargs_model, kwargs_cosmo, **kwargs_numerics)
+        r_list = np.logspace(-2, 1, 10)
+        for r in r_list:
+            for R in np.linspace(start=0, stop=r, num=5):
+                sigma_s2_analytic = analytic_kin.sigma_s2(r, R, {'theta_E': theta_E, 'gamma': gamma}, {'r_eff': r_eff}, kwargs_anisotropy)
+                sigma_s2_full_num = numeric_kin.sigma_s2_full(r, R, kwargs_mass, kwargs_light, kwargs_anisotropy)
+                npt.assert_almost_equal(sigma_s2_full_num/sigma_s2_analytic, 1, decimal=2)
+                #sigma_s2_num = numeric_kin.sigma_s2(r, R, kwargs_mass, kwargs_light, kwargs_anisotropy)
 
     def test_delete_cache(self):
         kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}

--- a/test/test_GalKin/test_numeric_kinematics.py
+++ b/test/test_GalKin/test_numeric_kinematics.py
@@ -107,7 +107,6 @@ class TestMassProfile(object):
                 sigma_s2_analytic = analytic_kin.sigma_s2(r, R, {'theta_E': theta_E, 'gamma': gamma}, {'r_eff': r_eff}, kwargs_anisotropy)
                 sigma_s2_full_num = numeric_kin.sigma_s2_full(r, R, kwargs_mass, kwargs_light, kwargs_anisotropy)
                 npt.assert_almost_equal(sigma_s2_full_num/sigma_s2_analytic, 1, decimal=2)
-                #sigma_s2_num = numeric_kin.sigma_s2(r, R, kwargs_mass, kwargs_light, kwargs_anisotropy)
 
     def test_delete_cache(self):
         kwargs_cosmo = {'d_d': 1000, 'd_s': 1500, 'd_ds': 800}

--- a/test/test_GalKin/test_velocity_util.py
+++ b/test/test_GalKin/test_velocity_util.py
@@ -57,6 +57,15 @@ class TestVelocityUtil(object):
         assert x_d != x
         assert y_d != y
 
+    def test_project_2d_random(self):
+        r = 1
+        R, x, y = velocity_util.project2d_random(r=r)
+        assert R <= r
+
+        r = np.linspace(0, 10, 100)
+        R, x, y = velocity_util.project2d_random(r=r)
+        assert len(R) == 100
+
 
 
 


### PR DESCRIPTION
numerical integrals in solving the Jean's equation are hard to stabilize and the numerical settings to put into `GalKin` need to be tested against an analytical version of the integrals, which only exists for a subset of the models. I changed the default numerical calculation to follow more directly the design of the analytical solutions and thus testing can occur also at lower levels on the accuracy requirements of each individual calculation. All API's of `GalKin` and `KinematicsAPI` remain unchanged and backwards compatible. Percent-level changes in accuracy of the predicted velocity dispersion for a given numerical setting can be expected.