### PR TITLE
Fix bug where lens equation solving parameters are not updated

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,4 +37,5 @@ Contributors (alphabetic)
 * Madison Ueland `mueland <https://github.com/mueland/>`_
 * Lyne Van de Vyvere `LyneVdV <https://github.com/LyneVdV/>`_
 * Cyril Welschen
+* Ewoud Wempe `ewoudwempe <https://github.com/ewoudwempe/>`_
 * Lilan Yang `ylilan <https://github.com/ylilan/>`_

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -77,7 +77,7 @@ class PointSource(object):
         :param only_from_unspecified: bool, if True, only sets keywords that previously have not been set
         :return: updated self instances
         """
-        if min_distance is not None and not (hasattr(self._kwargs_lens_eqn_solver, 'min_distance') and only_from_unspecified):
+        if min_distance is not None and not 'min_distance' in self._kwargs_lens_eqn_solver and only_from_unspecified:
             self._kwargs_lens_eqn_solver['min_distance'] = min_distance
         if only_from_unspecified:
             self._kwargs_lens_eqn_solver['search_window'] = self._kwargs_lens_eqn_solver.get('search_window', search_window)


### PR DESCRIPTION
This fixes the lens equation solving parameter update routine that did not work because `hasattr` does not test for dictionary keys (e.g. `hasattr({'a':1},a)` returns False).