### PR TITLE
Changed the truncated normal to a proper truncnorm distribution.

### DIFF
--- a/lenstronomy/Util/sampling_util.py
+++ b/lenstronomy/Util/sampling_util.py
@@ -9,10 +9,6 @@ export, __all__ = exporter()
 
 # transform the unit hypercube to pysical parameters for (nested) sampling
 
-
-SQRT2 = np.sqrt(2)
-
-
 @export
 def unit2uniform(x, vmin, vmax):
     """
@@ -72,7 +68,7 @@ def cube2args_gaussian(cube, lowers, uppers, means, sigmas, num_dims, copy=False
     if copy:
         cube_ = cube
         cube = np.zeros_like(cube_)
-    a, b = (lowers-means)/sigmas, (uppers-means)/sigmas
+    a, b = (np.array(lowers)-means)/sigmas, (np.array(uppers)-means)/sigmas
     cube[:] = stats.truncnorm.ppf(cube_ if copy else cube, a=a, b=b, loc=means, scale=sigmas)
     return cube
 

--- a/test/test_Util/test_sampling_util.py
+++ b/test/test_Util/test_sampling_util.py
@@ -5,13 +5,6 @@ import numpy.testing as npt
 from lenstronomy.Util import sampling_util
 
 
-def test_unit2gaussian():
-    mu, sigma = 5, 1
-    cube = np.linspace(0, 1, 3)
-    cube = sampling_util.unit2gaussian(cube, mu, sigma)
-    npt.assert_equal(cube, [-np.inf, mu, np.inf])
-
-
 def test_unit2uniform():
     lower, upper = -5, 15
     cube = np.linspace(0, 1, 3)


### PR DESCRIPTION
Instead of sampling from a Gaussian, and then clipping the values out of
bounds, sample from a truncated Gaussian from the start. This avoids an
effective delta-peak in the PDF at the bounds.