### PR TITLE
Allow specifiying constraints as a dictionary if the keys are not equal

### DIFF
--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -439,12 +439,19 @@ class Param(object):
         :param kwargs_list_1: list of keyword arguments
         :param kwargs_list_2: list of keyword arguments
         :param joint_setting_list: [[i_1, k_2, ['param_name1', 'param_name2', ...]], [...], ...]
+                                     or: [[i_1, k_2, {'param_old1': 'param_new1', 'ra_0': 'center_x'}], [...], ...]
         :return: updated kwargs_list_2 with arguments from kwargs_list_1 as defined in joint_setting_list
         """
         for setting in joint_setting_list:
             i_1, k_2, param_list = setting
-            for param_name in param_list:
-                kwargs_list_2[k_2][param_name] = kwargs_list_1[i_1][param_name]
+            if type(param_list) == list:
+                for param_name in param_list:
+                    kwargs_list_2[k_2][param_name] = kwargs_list_1[i_1][param_name]
+            elif type(param_list) == dict:
+                for param_to, param_from in param_list.items():
+                    kwargs_list_2[k_2][param_to] = kwargs_list_1[i_1][param_from]
+            else:
+                raise TypeError("Bad format for settings list")
         return kwargs_list_2
 
     @staticmethod

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -451,7 +451,7 @@ class Param(object):
                 for param_to, param_from in param_list.items():
                     kwargs_list_2[k_2][param_to] = kwargs_list_1[i_1][param_from]
             else:
-                raise TypeError("Bad format for settings list")
+                raise TypeError("Bad format for constraint setting: got %s" % param_list)
         return kwargs_list_2
 
     @staticmethod

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -152,7 +152,7 @@ class TestParam(object):
         param = Param(kwargs_model=kwargs_model, **kwargs_constraints)
         args = param.kwargs2args(kwargs_lens=kwargs_lens, kwargs_lens_light=kwargs_lens_light)
         kwargs_return = param.args2kwargs(args)
-        kwargs_lens_out = kwargs_return['kwargs_lens_light']
+        kwargs_lens_out = kwargs_return['kwargs_lens']
         kwargs_lens_light_out = kwargs_return['kwargs_lens_light']
         assert kwargs_lens_out[0]['w_c'] == kwargs_lens_light[0]['w_c']
         assert kwargs_lens_light_out[0]['w_c'] == kwargs_lens_light[0]['w_c']
@@ -171,6 +171,22 @@ class TestParam(object):
 
         assert kwargs_lens_out[0]['theta_E'] == kwargs_lens[0]['theta_E']
         assert kwargs_lens_out[0]['center_x'] == kwargs_lens_light[0]['center_x']
+
+    def test_joint_lens_with_light_dict(self):
+        kwargs_model = {'lens_model_list': ['SHEAR'], 'lens_light_model_list': ['SERSIC']}
+        i_light, k_lens = 0, 0
+        kwargs_constraints = {'joint_lens_with_light': [[i_light, k_lens, {'ra_0': 'center_x', 'dec_0': 'center_y'}]]}
+        kwargs_lens = [{'gamma1': 0.05, 'gamma2':0.06}]
+        kwargs_lens_light = [{'amp': 1, 'R_sersic': 1, 'n_sersic': 4, 'center_x': 0.1, 'center_y': 0.3}]
+        param = Param(kwargs_model=kwargs_model, **kwargs_constraints)
+        args = param.kwargs2args(kwargs_lens=kwargs_lens, kwargs_lens_light=kwargs_lens_light)
+        kwargs_return = param.args2kwargs(args)
+        kwargs_lens_out = kwargs_return['kwargs_lens']
+        kwargs_lens_light_out = kwargs_return['kwargs_lens_light']
+        assert kwargs_lens_out[0]['gamma1'] == kwargs_lens[0]['gamma1']
+        assert kwargs_lens_out[0]['ra_0'] == kwargs_lens_light[0]['center_x']
+        assert kwargs_lens_out[0]['dec_0'] == kwargs_lens_light[0]['center_y']
+
 
     def test_joint_source_with_point_source(self):
         kwargs_model = {'lens_model_list': ['SIS'], 'source_light_model_list': ['SERSIC'], 'point_source_model_list': ['SOURCE_POSITION']}


### PR DESCRIPTION
Useful e.g. to set the shear center at the lens center, not previously possible because 'ra_0' is not the same key as 'center_x', and the constraint function only set the same values.
If there was already a standard way of doing this, or if this belongs somewhere else, feel free to point me in the right direction and close this pull request.