### PR TITLE
access cosmology specified in LensModel in magnification_finite_adaptive

### DIFF
--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -72,13 +72,8 @@ class LensModelExtensions(object):
         """
 
         if cosmo is None:
-            # try to access a cosmology specified in the lens model first
-            try:
-                cosmo = self._lensModel.cosmo
-            except:
-                from astropy.cosmology import default_cosmology
-                cosmo = default_cosmology.get()
-
+            cosmo = self._lensModel.cosmo
+            
         # These default settings determined by guess and check seem adequate for sources with size 0.1 - 100 pc
         if grid_resolution is None:
             ref = 10.

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -72,8 +72,12 @@ class LensModelExtensions(object):
         """
 
         if cosmo is None:
-            from astropy.cosmology import default_cosmology
-            cosmo = default_cosmology.get()
+            # try to access a cosmology specified in the lens model first
+            try:
+                cosmo = self._lensModel.cosmo
+            except:
+                from astropy.cosmology import default_cosmology
+                cosmo = default_cosmology.get()
 
         # These default settings determined by guess and check seem adequate for sources with size 0.1 - 100 pc
         if grid_resolution is None:


### PR DESCRIPTION
I just added that attempts to access the cosmo attribute of _lensModel, and only reverts to the default astropy cosmology if the _lensModel class does not have a .cosmo attribute for whatever reason 