### PR TITLE
Multi plane cosmology interpolation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,6 +37,7 @@ Contributors (alphabetic)
 * Nicolas Tessore `ntessore <https://github.com/ntessore/>`_
 * Madison Ueland `mueland <https://github.com/mueland/>`_
 * Lyne Van de Vyvere `LyneVdV <https://github.com/LyneVdV/>`_
+* Sebastian Wagner-Carena `swagnercarena <https://github.com/swagnercarena>`_
 * Cyril Welschen
 * Ewoud Wempe `ewoudwempe <https://github.com/ewoudwempe/>`_
 * Lilan Yang `ylilan <https://github.com/ylilan/>`_

--- a/lenstronomy/Cosmo/background.py
+++ b/lenstronomy/Cosmo/background.py
@@ -45,6 +45,7 @@ class Background(object):
         :param z_source: source redshift
         :return: angular diameter distance in units of Mpc
         """
+        print(z_observer,z_source)
         D_xy = self.cosmo.angular_diameter_distance_z1z2(z_observer, z_source)
         return D_xy.value
 

--- a/lenstronomy/Cosmo/background.py
+++ b/lenstronomy/Cosmo/background.py
@@ -21,9 +21,9 @@ class Background(object):
         redshift
         :return: Background class with instance of astropy.cosmology
         """
-        from astropy.cosmology import default_cosmology
 
         if cosmo is None:
+            from astropy.cosmology import default_cosmology
             cosmo = default_cosmology.get()
         if interp:
             self.cosmo = CosmoInterp(cosmo, **kwargs_interp)

--- a/lenstronomy/Cosmo/background.py
+++ b/lenstronomy/Cosmo/background.py
@@ -45,7 +45,6 @@ class Background(object):
         :param z_source: source redshift
         :return: angular diameter distance in units of Mpc
         """
-        print(z_observer,z_source)
         D_xy = self.cosmo.angular_diameter_distance_z1z2(z_observer, z_source)
         return D_xy.value
 

--- a/lenstronomy/Cosmo/background.py
+++ b/lenstronomy/Cosmo/background.py
@@ -3,6 +3,7 @@ __author__ = 'sibirrer'
 
 import numpy as np
 import lenstronomy.Util.constants as const
+from lenstronomy.Cosmo.cosmo_interp import CosmoInterp
 
 __all__ = ['Background']
 
@@ -11,17 +12,23 @@ class Background(object):
     """
     class to compute cosmological distances
     """
-    def __init__(self, cosmo=None):
+    def __init__(self, cosmo=None, interp=False, **kwargs_interp):
         """
 
         :param cosmo: instance of astropy.cosmology
+        :param interp: boolean, if True, uses interpolated cosmology to evaluate specific redshifts
+        :param kwargs_interp: keyword arguments of CosmoInterp specifying the interpolation interval and maximum
+        redshift
         :return: Background class with instance of astropy.cosmology
         """
         from astropy.cosmology import default_cosmology
 
         if cosmo is None:
             cosmo = default_cosmology.get()
-        self.cosmo = cosmo
+        if interp:
+            self.cosmo = CosmoInterp(cosmo, **kwargs_interp)
+        else:
+            self.cosmo = cosmo
 
     def a_z(self, z):
         """

--- a/lenstronomy/Cosmo/cosmo_interp.py
+++ b/lenstronomy/Cosmo/cosmo_interp.py
@@ -1,0 +1,203 @@
+from astropy.cosmology.core import vectorize_if_needed, isiterable
+from astropy import units
+from math import sqrt
+import numpy as np
+import copy
+from scipy.interpolate import interp1d
+
+
+class CosmoInterp(object):
+    """
+    class which interpolates the comoving transfer distance and then computes angular diameter distances from it
+    This class is modifying the astropy.cosmology routines
+    """
+    def __init__(self, cosmo, z_stop, num_interp):
+        """
+
+        :param cosmo: astropy.cosmology instance (version 4.0 as private functions need to be supported)
+        :param z_stop: maximum redshift for the interpolation
+        :param num_interp: int, number of interpolating steps
+        """
+        self._cosmo = cosmo
+        self._comoving_distance_interpolation_func = self._interpolate_comoving_distance(z_start=0, z_stop=z_stop,
+                                                                             num_interp=num_interp)
+
+    def _comoving_distance_interp(self, z):
+        """
+
+        :param z: redshift to which the comoving distance is calculated
+        :return: comoving distance in units Mpc
+        """
+        return self._comoving_distance_interpolation_func(z) * units.Mpc
+
+    def angular_diameter_distance(self, z):
+        """ Angular diameter distance in Mpc at a given redshift.
+
+        This gives the proper (sometimes called 'physical') transverse
+        distance corresponding to an angle of 1 radian for an object
+        at redshift ``z``.
+
+        Weinberg, 1972, pp 421-424; Weedman, 1986, pp 65-67; Peebles,
+        1993, pp 325-327.
+
+        Parameters
+        ----------
+        z : array_like
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Angular diameter distance in Mpc at each input redshift.
+        """
+
+        if isiterable(z):
+            z = np.asarray(z)
+
+        return self.comoving_transverse_distance(z) / (1. + z)
+
+    def angular_diameter_distance_z1z2(self, z1, z2):
+        """ Angular diameter distance between objects at 2 redshifts.
+        Useful for gravitational lensing.
+
+        Parameters
+        ----------
+        z1, z2 : array_like, shape (N,)
+          Input redshifts. z2 must be large than z1.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`, shape (N,) or single if input scalar
+          The angular diameter distance between each input redshift
+          pair.
+
+        """
+
+        z1 = np.asanyarray(z1)
+        z2 = np.asanyarray(z2)
+        return self._comoving_transverse_distance_z1z2(z1, z2) / (1. + z2)
+
+    def comoving_transverse_distance(self, z):
+        """ Comoving transverse distance in Mpc at a given redshift.
+
+        This value is the transverse comoving distance at redshift ``z``
+        corresponding to an angular separation of 1 radian. This is
+        the same as the comoving distance if omega_k is zero (as in
+        the current concordance lambda CDM model).
+
+        Parameters
+        ----------
+        z : array_like
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving transverse distance in Mpc at each input redshift.
+
+        Notes
+        -----
+        This quantity also called the 'proper motion distance' in some
+        texts.
+        """
+
+        return self._comoving_transverse_distance_z1z2(0, z)
+
+    def _comoving_transverse_distance_z1z2(self, z1, z2):
+        """Comoving transverse distance in Mpc between two redshifts.
+
+        This value is the transverse comoving distance at redshift
+        ``z2`` as seen from redshift ``z1`` corresponding to an
+        angular separation of 1 radian. This is the same as the
+        comoving distance if omega_k is zero (as in the current
+        concordance lambda CDM model).
+
+        Parameters
+        ----------
+        z1, z2 : array_like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving transverse distance in Mpc between input redshift.
+
+        Notes
+        -----
+        This quantity is also called the 'proper motion distance' in
+        some texts.
+
+        """
+
+        Ok0 = self._cosmo._Ok0
+        dc = self._comoving_distance_z1z2(z1, z2)
+        if Ok0 == 0:
+            return dc
+        sqrtOk0 = sqrt(abs(Ok0))
+        dh = self._cosmo._hubble_distance
+        if Ok0 > 0:
+            return dh / sqrtOk0 * np.sinh(sqrtOk0 * dc.value / dh.value)
+        else:
+            return dh / sqrtOk0 * np.sin(sqrtOk0 * dc.value / dh.value)
+
+    def _comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at
+        redshifts z1 and z2.
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        Parameters
+        ----------
+        z1, z2 : array_like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+        return self._comoving_distance_interp(z2) - self._comoving_distance_interp(z1)
+
+    def _interpolate_comoving_distance(self, z_start, z_stop, num_interp):
+        """
+        interpolates the comoving distance
+
+        :param z_start: starting redshift range (should be zero)
+        :param z_stop: highest redshift to which to compute the comoving distance
+        :param num_interp: number of steps uniformly spread in redshift
+        :return: interpolation object in this class
+        """
+        z_steps = np.linspace(start=z_start, stop=z_stop, num=num_interp+1)
+        running_dist = 0
+        ang_dist = np.zeros(num_interp+1)
+        for i in range(num_interp):
+            delta_dist = self._integral_comoving_distance_z1z2(z_steps[i], z_steps[i+1])
+            running_dist += delta_dist.value
+            ang_dist[i+1] = copy.deepcopy(running_dist)
+        return interp1d(z_steps, ang_dist)
+
+    def _integral_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at
+        redshifts z1 and z2.
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        Parameters
+        ----------
+        z1, z2 : array_like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+
+        from scipy.integrate import quad
+        f = lambda z1, z2: quad(self._cosmo._inv_efunc_scalar, z1, z2,
+                             args=self._cosmo._inv_efunc_scalar_args)[0]
+        return self._cosmo._hubble_distance * vectorize_if_needed(f, z1, z2)

--- a/lenstronomy/Cosmo/cosmo_interp.py
+++ b/lenstronomy/Cosmo/cosmo_interp.py
@@ -20,7 +20,7 @@ class CosmoInterp(object):
         """
         self._cosmo = cosmo
         self._comoving_distance_interpolation_func = self._interpolate_comoving_distance(z_start=0, z_stop=z_stop,
-                                                                             num_interp=num_interp)
+                                                                                         num_interp=num_interp)
 
     def _comoving_distance_interp(self, z):
         """

--- a/lenstronomy/LensModel/Profiles/interpol.py
+++ b/lenstronomy/LensModel/Profiles/interpol.py
@@ -58,7 +58,7 @@ class Interpol(LensProfileBase):
         else:
             if self._grid and n >= self._min_grid_number:
                 x_axes, y_axes = util.get_axes(x, y)
-                f_out = self.f_interp(x_axes, y_axes, grid_interp_x, grid_interp_y, f_)
+                f_out = self.f_interp(x_axes, y_axes, grid_interp_x, grid_interp_y, f_, grid=self._grid)
                 f_out = util.image2array(f_out)
             else:
                 #n = len(x)
@@ -92,16 +92,14 @@ class Interpol(LensProfileBase):
         else:
             if self._grid and n >= self._min_grid_number:
                 x_, y_ = util.get_axes(x, y)
-                f_x_out = self.f_x_interp(x_, y_, grid_interp_x, grid_interp_y, f_x)
-                f_y_out = self.f_y_interp(x_, y_, grid_interp_x, grid_interp_y, f_y)
+                f_x_out = self.f_x_interp(x_, y_, grid_interp_x, grid_interp_y, f_x, grid=self._grid)
+                f_y_out = self.f_y_interp(x_, y_, grid_interp_x, grid_interp_y, f_y, grid=self._grid)
                 f_x_out = util.image2array(f_x_out)
                 f_y_out = util.image2array(f_y_out)
             else:
                 #n = len(x)
-                f_x_out, f_y_out = np.zeros(n), np.zeros(n)
-                for i in range(n):
-                    f_x_out[i] = self.f_x_interp(x[i], y[i], grid_interp_x, grid_interp_y, f_x)
-                    f_y_out[i] = self.f_y_interp(x[i], y[i], grid_interp_x, grid_interp_y, f_y)
+                f_x_out = self.f_x_interp(x, y, grid_interp_x, grid_interp_y, f_x)
+                f_y_out = self.f_y_interp(x, y, grid_interp_x, grid_interp_y, f_y)
         return f_x_out, f_y_out
 
     def hessian(self, x, y, grid_interp_x=None, grid_interp_y=None, f_=None, f_x=None, f_y=None, f_xx=None, f_yy=None, f_xy=None):
@@ -130,9 +128,9 @@ class Interpol(LensProfileBase):
         else:
             if self._grid and n >= self._min_grid_number:
                 x_, y_ = util.get_axes(x, y)
-                f_xx_out = self.f_xx_interp(x_, y_, grid_interp_x, grid_interp_y, f_xx)
-                f_yy_out = self.f_yy_interp(x_, y_, grid_interp_x, grid_interp_y, f_yy)
-                f_xy_out = self.f_xy_interp(x_, y_, grid_interp_x, grid_interp_y, f_xy)
+                f_xx_out = self.f_xx_interp(x_, y_, grid_interp_x, grid_interp_y, f_xx, grid=self._grid)
+                f_yy_out = self.f_yy_interp(x_, y_, grid_interp_x, grid_interp_y, f_yy, grid=self._grid)
+                f_xy_out = self.f_xy_interp(x_, y_, grid_interp_x, grid_interp_y, f_xy, grid=self._grid)
                 f_xx_out = util.image2array(f_xx_out)
                 f_yy_out = util.image2array(f_yy_out)
                 f_xy_out = util.image2array(f_xy_out)
@@ -145,35 +143,35 @@ class Interpol(LensProfileBase):
                     f_xy_out[i] = self.f_xy_interp(x[i], y[i], grid_interp_x, grid_interp_y, f_xy)
         return f_xx_out, f_yy_out, f_xy_out
 
-    def f_interp(self, x, y, x_grid=None, y_grid=None, f_=None):
+    def f_interp(self, x, y, x_grid=None, y_grid=None, f_=None, grid=False):
         if not hasattr(self, '_f_interp'):
             self._f_interp = scipy.interpolate.RectBivariateSpline(y_grid, x_grid, f_, kx=1, ky=1, s=0)
-        return self._f_interp(y, x)
+        return self._f_interp(y, x, grid=grid)
 
-    def f_x_interp(self, x, y, x_grid=None, y_grid=None, f_x=None):
+    def f_x_interp(self, x, y, x_grid=None, y_grid=None, f_x=None, grid=False):
         if not hasattr(self, '_f_x_interp'):
             self._f_x_interp = scipy.interpolate.RectBivariateSpline(y_grid, x_grid, f_x, kx=1, ky=1, s=0)
-        return self._f_x_interp(y, x)
+        return self._f_x_interp(y, x, grid=grid)
 
-    def f_y_interp(self, x, y, x_grid=None, y_grid=None, f_y=None):
+    def f_y_interp(self, x, y, x_grid=None, y_grid=None, f_y=None, grid=False):
         if not hasattr(self, '_f_y_interp'):
             self._f_y_interp = scipy.interpolate.RectBivariateSpline(y_grid, x_grid, f_y, kx=1, ky=1, s=0)
-        return self._f_y_interp(y, x)
+        return self._f_y_interp(y, x, grid=grid)
 
-    def f_xx_interp(self, x, y, x_grid=None, y_grid=None, f_xx=None):
+    def f_xx_interp(self, x, y, x_grid=None, y_grid=None, f_xx=None, grid=False):
         if not hasattr(self, '_f_xx_interp'):
             self._f_xx_interp = scipy.interpolate.RectBivariateSpline(y_grid, x_grid, f_xx, kx=1, ky=1, s=0)
-        return self._f_xx_interp(y, x)
+        return self._f_xx_interp(y, x, grid=grid)
 
-    def f_xy_interp(self, x, y, x_grid=None, y_grid=None, f_xy=None):
+    def f_xy_interp(self, x, y, x_grid=None, y_grid=None, f_xy=None, grid=False):
         if not hasattr(self, '_f_xy_interp'):
             self._f_xy_interp = scipy.interpolate.RectBivariateSpline(y_grid, x_grid, f_xy, kx=1, ky=1, s=0)
-        return self._f_xy_interp(y, x)
+        return self._f_xy_interp(y, x, grid=grid)
 
-    def f_yy_interp(self, x, y, x_grid=None, y_grid=None, f_yy=None):
+    def f_yy_interp(self, x, y, x_grid=None, y_grid=None, f_yy=None, grid=False):
         if not hasattr(self, '_f_yy_interp'):
             self._f_yy_interp = scipy.interpolate.RectBivariateSpline(y_grid, x_grid, f_yy, kx=1, ky=1, s=0)
-        return self._f_yy_interp(y, x)
+        return self._f_yy_interp(y, x, grid=grid)
 
     def do_interp(self, x_grid, y_grid, f_, f_x, f_y, f_xx=None, f_yy=None, f_xy=None):
         self._f_interp = scipy.interpolate.RectBivariateSpline(x_grid, y_grid, f_, kx=1, ky=1, s=0)

--- a/lenstronomy/LensModel/Profiles/interpol.py
+++ b/lenstronomy/LensModel/Profiles/interpol.py
@@ -54,7 +54,7 @@ class Interpol(LensProfileBase):
         if n <= 1 and np.shape(x) == ():
         #if type(x) == float or type(x) == int or type(x) == type(np.float64(1)) or len(x) <= 1:
             f_out = self.f_interp(x, y, grid_interp_x, grid_interp_y, f_)
-            return f_out[0][0]
+            return f_out
         else:
             if self._grid and n >= self._min_grid_number:
                 x_axes, y_axes = util.get_axes(x, y)
@@ -88,7 +88,7 @@ class Interpol(LensProfileBase):
         #if type(x) == float or type(x) == int or type(x) == type(np.float64(1)) or len(x) <= 1:
             f_x_out = self.f_x_interp(x, y, grid_interp_x, grid_interp_y, f_x)
             f_y_out = self.f_y_interp(x, y, grid_interp_x, grid_interp_y, f_y)
-            return f_x_out[0][0], f_y_out[0][0]
+            return f_x_out, f_y_out
         else:
             if self._grid and n >= self._min_grid_number:
                 x_, y_ = util.get_axes(x, y)
@@ -124,7 +124,7 @@ class Interpol(LensProfileBase):
             f_xx_out = self.f_xx_interp(x, y, grid_interp_x, grid_interp_y, f_xx)
             f_yy_out = self.f_yy_interp(x, y, grid_interp_x, grid_interp_y, f_yy)
             f_xy_out = self.f_xy_interp(x, y, grid_interp_x, grid_interp_y, f_xy)
-            return f_xx_out[0][0], f_yy_out[0][0], f_xy_out[0][0]
+            return f_xx_out, f_yy_out, f_xy_out
         else:
             if self._grid and n >= self._min_grid_number:
                 x_, y_ = util.get_axes(x, y)

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -3,7 +3,6 @@ __author__ = 'sibirrer'
 from lenstronomy.LensModel.single_plane import SinglePlane
 from lenstronomy.LensModel.multi_plane import MultiPlane
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
-from astropy.cosmology import default_cosmology
 from lenstronomy.Util import constants as const
 
 __all__ = ['LensModel']
@@ -16,7 +15,7 @@ class LensModel(object):
 
     def __init__(self, lens_model_list, z_lens=None, z_source=None, lens_redshift_list=None, cosmo=None,
                  multi_plane=False, numerical_alpha_class=None, observed_convention_index=None,
-                 z_source_convention=None):
+                 z_source_convention=None, cosmo_interp=False, z_interp_stop=None, num_z_interp=100):
         """
 
         :param lens_model_list: list of strings with lens model names
@@ -35,16 +34,21 @@ class LensModel(object):
         positions. The code will compute the physical locations when performing computations
         :param z_source_convention: float, redshift of a source to define the reduced deflection angles of the lens
         models. If None, 'z_source' is used.
+        :param cosmo_interp: boolean (only employed in multi-plane mode), interpolates astropy.cosmology distances for
+        faster calls when accessing several lensing planes
+        :param z_interp_stop: (only in multi-plane with cosmo_interp=True); maximum redshift for distance interpolation
+        This number should be higher or equal the maximum of the source redshift and/or the z_source_convention
+        :param num_z_interp: (only in multi-plane with cosmo_interp=True); number of redshift bins for interpolating
+        distances
         """
         self.lens_model_list = lens_model_list
         self.z_lens = z_lens
-        if z_source_convention is None:
-            z_source_convention = z_source
         self.z_source = z_source
         self._z_source_convention = z_source_convention
         self.redshift_list = lens_redshift_list
 
         if cosmo is None:
+            from astropy.cosmology import default_cosmology
             cosmo = default_cosmology.get()
         self.cosmo = cosmo
         self.multi_plane = multi_plane
@@ -55,7 +59,8 @@ class LensModel(object):
             self.lens_model = MultiPlane(z_source, lens_model_list, lens_redshift_list, cosmo=cosmo,
                                          numerical_alpha_class=numerical_alpha_class,
                                          observed_convention_index=observed_convention_index,
-                                         z_source_convention=z_source_convention)
+                                         z_source_convention=z_source_convention, cosmo_interp=cosmo_interp,
+                                         z_interp_stop=z_interp_stop, num_z_interp=num_z_interp)
         else:
             self.lens_model = SinglePlane(lens_model_list, numerical_alpha_class=numerical_alpha_class,
                                           lens_redshift_list=lens_redshift_list,

--- a/lenstronomy/LensModel/multi_plane.py
+++ b/lenstronomy/LensModel/multi_plane.py
@@ -16,7 +16,8 @@ class MultiPlane(object):
     """
 
     def __init__(self, z_source, lens_model_list, lens_redshift_list, cosmo=None, numerical_alpha_class=None,
-                 observed_convention_index=None, ignore_observed_positions=False, z_source_convention=None):
+                 observed_convention_index=None, ignore_observed_positions=False, z_source_convention=None,
+                 cosmo_interp=False, z_interp_stop=None, num_z_interp=100):
         """
 
         :param z_source: source redshift for default computation of reduced lensing quantities
@@ -36,10 +37,15 @@ class MultiPlane(object):
 
         if z_source_convention is None:
             z_source_convention = z_source
+        if z_interp_stop is None:
+            z_interp_stop = max(z_source, z_source_convention)
+        if z_interp_stop < max(z_source, z_source_convention):
+            raise ValueError('z_interp_stop= %s needs to be larger or equal the maximum of z_source=%s and z_source_convention=%s' % (z_interp_stop, z_source, z_source_convention))
         self._multi_plane_base = MultiPlaneBase(lens_model_list=lens_model_list,
                                                 lens_redshift_list=lens_redshift_list, cosmo=cosmo,
                                                 numerical_alpha_class=numerical_alpha_class,
-                                                z_source_convention=z_source_convention)
+                                                z_source_convention=z_source_convention, cosmo_interp=cosmo_interp,
+                                                z_interp_stop=z_interp_stop, num_z_interp=num_z_interp)
 
         self._set_source_distances(z_source)
         self._observed_convention_index = observed_convention_index

--- a/lenstronomy/LensModel/multi_plane_base.py
+++ b/lenstronomy/LensModel/multi_plane_base.py
@@ -16,7 +16,7 @@ class MultiPlaneBase(ProfileListBase):
     """
 
     def __init__(self, lens_model_list, lens_redshift_list, z_source_convention, cosmo=None,
-                 numerical_alpha_class=None):
+                 numerical_alpha_class=None, cosmo_interp=True, z_interp_stop=None, num_z_interp=100):
         """
 
         :param lens_model_list: list of lens model strings
@@ -28,7 +28,9 @@ class MultiPlaneBase(ProfileListBase):
          (see documentation in Profiles/numerical_alpha)
 
         """
-        self._cosmo_bkg = Background(cosmo)
+        if z_interp_stop is None:
+            z_interp_stop = z_source_convention
+        self._cosmo_bkg = Background(cosmo, interp=cosmo_interp, z_stop=z_interp_stop, num_interp=num_z_interp)
         self._z_source_convention = z_source_convention
         if len(lens_redshift_list) > 0:
             z_lens_max = np.max(lens_redshift_list)

--- a/lenstronomy/LensModel/multi_plane_base.py
+++ b/lenstronomy/LensModel/multi_plane_base.py
@@ -59,7 +59,8 @@ class MultiPlaneBase(ProfileListBase):
             self._reduced2physical_factor = []
         else:
             z_sort = np.array(self._lens_redshift_list)[self._sorted_redshift_index]
-            self._reduced2physical_factor = self._cosmo_bkg.d_xy(0, z_source_convention) / self._cosmo_bkg.d_xy(z_sort, z_source_convention)
+            z_source_array = np.ones(z_sort.shape)*z_source_convention
+            self._reduced2physical_factor = self._cosmo_bkg.d_xy(0, z_source_convention) / self._cosmo_bkg.d_xy(z_sort, z_source_array)
         for idex in self._sorted_redshift_index:
             z_lens = self._lens_redshift_list[idex]
             if z_before == z_lens:

--- a/test/test_Cosmo/test_background.py
+++ b/test/test_Cosmo/test_background.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy.testing as npt
 
 from lenstronomy.Cosmo.background import Background
 
@@ -18,6 +19,16 @@ class TestCosmoProp(object):
 
     def test_rho_crit(self):
         assert self.bkg.rho_crit == 135955133951.10692
+
+    def test_interpol(self):
+        from astropy.cosmology import FlatLambdaCDM
+        cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
+        bkg = Background(cosmo=cosmo)
+
+        bkg_interp = Background(cosmo=cosmo, interp=True, num_interp=100, z_stop=10)
+        d_xy = bkg.d_xy(z_observer=0.1, z_source=0.8)
+        d_xy_interp = bkg_interp.d_xy(z_observer=0.1, z_source=0.8)
+        npt.assert_almost_equal(d_xy_interp / d_xy, 1, decimal=5)
 
 
 if __name__ == '__main__':

--- a/test/test_Cosmo/test_cosmo_interp.py
+++ b/test/test_Cosmo/test_cosmo_interp.py
@@ -1,0 +1,71 @@
+import pytest
+import numpy.testing as npt
+from astropy.cosmology import FlatLambdaCDM, LambdaCDM
+from lenstronomy.Cosmo.cosmo_interp import CosmoInterp
+
+
+class TestCosmoInterp(object):
+    """
+
+    """
+    def setup(self):
+        self.H0_true = 70
+        self.omega_m_true = 0.3
+        self._ok_true = 0.1
+        self.cosmo = FlatLambdaCDM(H0=self.H0_true, Om0=self.omega_m_true, Ob0=0.05)
+        self.cosmo_interp = CosmoInterp(cosmo=self.cosmo, z_stop=3, num_interp=100)
+        self.cosmo_ok = LambdaCDM(H0=self.H0_true, Om0=self.omega_m_true, Ode0=1.0 - self.omega_m_true - self._ok_true)
+        self.cosmo_interp_ok = CosmoInterp(cosmo=self.cosmo_ok, z_stop=3, num_interp=100)
+
+        self.cosmo_ok_neg = LambdaCDM(H0=self.H0_true, Om0=self.omega_m_true, Ode0=1.0 - self.omega_m_true + self._ok_true)
+        self.cosmo_interp_ok_neg = CosmoInterp(cosmo=self.cosmo_ok_neg, z_stop=3, num_interp=100)
+
+    def test_angular_diameter_distance(self):
+        z = 1.
+        da = self.cosmo.angular_diameter_distance(z=[z])
+        da_interp = self.cosmo_interp.angular_diameter_distance(z=[z])
+        npt.assert_almost_equal(da_interp/da, 1, decimal=3)
+        assert da.unit == da_interp.unit
+
+        da = self.cosmo_ok.angular_diameter_distance(z=z)
+        da_interp = self.cosmo_interp_ok.angular_diameter_distance(z=z)
+        npt.assert_almost_equal(da_interp / da, 1, decimal=3)
+        assert da.unit == da_interp.unit
+
+        da = self.cosmo_ok_neg.angular_diameter_distance(z=z)
+        da_interp = self.cosmo_interp_ok_neg.angular_diameter_distance(z=z)
+        npt.assert_almost_equal(da_interp / da, 1, decimal=3)
+        assert da.unit == da_interp.unit
+
+    def test_angular_diameter_distance_array(self):
+        # test for array input
+        z1 = 1.
+        z2 = 2.
+        da_z1 = self.cosmo.angular_diameter_distance(z=[z1])
+        da_z2 = self.cosmo.angular_diameter_distance(z=[z2])
+        da_interp = self.cosmo_interp.angular_diameter_distance(z=[z1, z2])
+        npt.assert_almost_equal(da_interp[0] / da_z1, 1, decimal=3)
+        npt.assert_almost_equal(da_interp[1] / da_z2, 1, decimal=3)
+        assert da_z1.unit == da_interp.unit
+        assert len(da_interp) == 2
+
+        da_z12 = self.cosmo.angular_diameter_distance(z=[z1, z2])
+        npt.assert_almost_equal(da_z12[0] / da_z1, 1, decimal=3)
+        npt.assert_almost_equal(da_z12[1] / da_z2, 1, decimal=3)
+
+    def test_angular_diameter_distance_z1z2(self):
+        z1 = .3
+        z2 = 2.
+        delta_a = self.cosmo.angular_diameter_distance_z1z2(z1=z1, z2=z2)
+        delta_a_interp = self.cosmo_interp.angular_diameter_distance_z1z2(z1=z1, z2=z2)
+        npt.assert_almost_equal(delta_a_interp/delta_a, 1, decimal=3)
+        assert delta_a.unit == delta_a_interp.unit
+
+        delta_a = self.cosmo_ok.angular_diameter_distance_z1z2(z1=z1, z2=z2)
+        delta_a_interp = self.cosmo_interp_ok.angular_diameter_distance_z1z2(z1=z1, z2=z2)
+        npt.assert_almost_equal(delta_a_interp / delta_a, 1, decimal=3)
+        assert delta_a.unit == delta_a_interp.unit
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/test/test_LensModel/test_multi_plane.py
+++ b/test/test_LensModel/test_multi_plane.py
@@ -24,7 +24,7 @@ class TestMultiPlane(object):
         kwargs_lens = [{'theta_E': 1}]
         redshift_list = [0.5]
         lensModelMutli = MultiPlane(z_source=z_source, lens_model_list=lens_model_list,
-                                    lens_redshift_list=redshift_list)
+                                    lens_redshift_list=redshift_list, z_interp_stop=3, cosmo_interp=True)
         alpha_x, alpha_y = lensModelMutli.alpha(1, 0, kwargs_lens=kwargs_lens)
         lensModelMutli.update_source_redshift(z_source=z_source)
         alpha_x_new, alpha_y_new = lensModelMutli.alpha(1, 0, kwargs_lens=kwargs_lens)
@@ -367,6 +367,10 @@ class TestRaise(unittest.TestCase):
         with self.assertRaises(ValueError):
             lens = MultiPlane(z_source_convention=1, z_source=1, lens_model_list=['SIS', 'SIS'], lens_redshift_list=[0.5, 0.8])
             lens._check_raise(k=[1])
+
+        with self.assertRaises(ValueError):
+            lens_model = LensModel(lens_model_list=['SIS'], multi_plane=True, z_source=1, z_source_convention=1,
+                                   cosmo_interp=True, z_interp_stop=0.5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR allows to initiate and call an interpolated cosmology back end to satrapy.cosmology with the aim for a faster LensModel() class instantiation with hundreds of lensing planes, when the options are chosen.