### PR TITLE
Added a new fast implementation of the EPL profile

### DIFF
--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -148,8 +148,8 @@ def alpha(x, y, b, q, t):
     R = np.abs(zz)
     phi = np.angle(zz)
     Omega = omega(phi, t, q)
-    alph = (2*b)/(1+q)*(b/R)**t*R/b*Omega
-    return nan_to_num(alph)
+    alph = (2*b)/(1+q)*nan_to_num((b/R)**t*R/b)*Omega
+    return alph
 
 @jit(fastmath=True) # Because of the reduction nature of this, relaxing commutativity actually matters a lot (4x speedup).
 def omega(phi, t, q, niter_max=200, tol=1e-16):

--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -4,7 +4,7 @@ import numpy as np
 import numba as nb
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
-from lenstronomy.Util.numba_util import jit
+from lenstronomy.Util.numba_util import jit, nan_to_num
 
 __all__ = ['EPL_numba']
 
@@ -110,32 +110,6 @@ def param_transform(x, y, theta_E, gamma, e1, e2, center_x=0., center_y=0.):
     z = np.exp(-1j*phi_G) * (x_shift + y_shift*1j)
     return z, theta_E*np.sqrt(q), t, q, ang
 
-
-from lenstronomy.Util.numba_util import jit
-@nb.generated_jit(nopython=True, cache=True)
-def nan_to_num(x, inf=-1e10, nan=0):
-    """Converts the nans in an array or scalar and returns the (overwritten) array or scalar.
-    This is necessary because of the need to support both arrays and scalars for all input functions.
-    """
-    if isinstance(x, nb.types.Array) and x.ndim > 0:
-        return nan_to_num_arr
-    else:
-        return nan_to_num_single
-
-@jit()
-def nan_to_num_arr(x, inf=1e10, nan=0):
-    x[np.isnan(x)] = nan
-    x[np.isinf(x)] = inf
-    return x
-
-@jit()
-def nan_to_num_single(x, inf=1e10, nan=0):
-    if np.isfinite(x):
-        return x
-    elif np.isinf(x):
-        return inf
-    else:
-        return nan
 
 @jit()
 def alpha(x, y, b, q, t):

--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -60,8 +60,7 @@ class EPL_numba(LensProfileBase):
         """
         z, b, t, q, ang = param_transform(x, y, theta_E, e1, e2, gamma, center_x, center_y)
         alph = alpha(z.real, z.imag, b, q, t)
-        # Fix the nans if x=y=0 is filled in
-        return nan_to_num(1/(2-t)*(z.real*alph.real+z.imag*alph.imag))
+        return 1/(2-t)*(z.real*alph.real+z.imag*alph.imag)
 
     @staticmethod
     @jit()
@@ -80,7 +79,7 @@ class EPL_numba(LensProfileBase):
         """
         z, b, t, q, ang = param_transform(x, y, theta_E, e1, e2, gamma, center_x, center_y)
         alph = alpha(z.real, z.imag, b, q, t) * np.exp(1j*ang)
-        return nan_to_num(alph.real), nan_to_num(alph.imag)
+        return alph.real, alph.imag
 
     @staticmethod
     @jit()
@@ -148,11 +147,9 @@ def alpha(x, y, b, q, t):
     zz = x*q + 1j*y
     R = np.abs(zz)
     phi = np.angle(zz)
-    #if Omega is None:
-        #Omega = omega(phi, t, q)
     Omega = omega(phi, t, q)
-    alph = (2*b)/(1+q)*(b/R)**(t-1)*Omega
-    return alph
+    alph = (2*b)/(1+q)*(b/R)**t*R/b*Omega
+    return nan_to_num(alph)
 
 @jit(fastmath=True) # Because of the reduction nature of this, relaxing commutativity actually matters a lot (4x speedup).
 def omega(phi, t, q, niter_max=200, tol=1e-16):

--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -1,0 +1,154 @@
+__author__ = 'ewoudwempe'
+
+import numpy as np
+import numba as nb
+import lenstronomy.Util.param_util as param_util
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from lenstronomy.Util.numba_util import jit
+
+__all__ = ['EPL_numba']
+
+
+class EPL_numba(LensProfileBase):
+    """
+    class for power law ellipse mass density profile. Follows the formulas from Tessore+ (2015).
+
+    The Einstein ring parameter converts to the definition used by GRAVLENS as follow:
+    (theta_E / theta_E_gravlens) = sqrt[ (1+q^2) / (2 q) ]
+    """
+    param_names = ['theta_E', 'gamma', 'e1', 'e2', 'center_x', 'center_y']
+    lower_limit_default = {'theta_E': 0, 'gamma': 1., 'e1': -0.5, 'e2': -0.5, 'center_x': -100, 'center_y': -100}
+    upper_limit_default = {'theta_E': 100, 'gamma': 3., 'e1': 0.5, 'e2': 0.5, 'center_x': 100, 'center_y': 100}
+
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    @jit()
+    def function(x, y, theta_E, gamma, e1, e2, center_x=0., center_y=0.):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y-coordinate (angle)
+        :param theta_E: Einstein radius (angle), pay attention to specific definition!
+        :param gamma: logarithmic slope of the power-law profile. gamma=2 corresponds to isothermal
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param center_x: x-position of lens center
+        :param center_y: y-position of lens center
+        :return: lensing potential
+        """
+        z, b, t, q, ang = param_transform(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+        alph = alpha(z.real, z.imag, b, q, t)
+        # Fix the nans if x=y=0 is filled in
+        return 1/(2-t)*(z.real*alph.real+z.imag*alph.imag)
+
+    @staticmethod
+    @jit()
+    def derivatives(x, y, theta_E, gamma, e1, e2, center_x=0., center_y=0.):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y-coordinate (angle)
+        :param theta_E: Einstein radius (angle), pay attention to specific definition!
+        :param gamma: logarithmic slope of the power-law profile. gamma=2 corresponds to isothermal
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param center_x: x-position of lens center
+        :param center_y: y-position of lens center
+        :return: deflection angles alpha_x, alpha_y
+        """
+        z, b, t, q, ang = param_transform(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+        alph = alpha(z.real, z.imag, b, q, t) * np.exp(1j*ang)
+        return alph.real, alph.imag
+
+    @staticmethod
+    @jit()
+    def hessian(x, y, theta_E, gamma, e1, e2, center_x=0., center_y=0.):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y-coordinate (angle)
+        :param theta_E: Einstein radius (angle), pay attention to specific definition!
+        :param gamma: logarithmic slope of the power-law profile. gamma=2 corresponds to isothermal
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param center_x: x-position of lens center
+        :param center_y: y-position of lens center
+        :return: Hessian components f_xx, f_yy, f_xy
+        """
+        z, b, t, q, ang_ell = param_transform(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+        ang = np.angle(z)
+        r = np.abs(z)
+        zz_ell = z.real*q+1j*z.imag
+        R = np.abs(zz_ell)
+        phi = np.angle(zz_ell)
+
+        kappa = (2-t)/2*(b/R)**t
+
+        Omega = omega(phi, t, q)
+        alph = (2*b)/(1+q)*(b/R)**(t-1)*Omega
+        gamma_shear = -np.exp(2j*(ang+ang_ell))*kappa + (1-t)*np.exp(1j*(ang+2*ang_ell)) * alph/r
+
+        f_xx = kappa + gamma_shear.real
+        f_yy = kappa - gamma_shear.real
+        f_xy = gamma_shear.imag
+        # Fix the nans if x=y=0 is filled in
+
+        return nan_to_zero(f_xx), nan_to_zero(f_yy), nan_to_zero(f_xy)
+
+@jit()
+def param_transform(x, y, theta_E, gamma, e1, e2, center_x=0., center_y=0.):
+    """Converts the parameters from lenstronomy definitions (as defined in PEMD) to the definitions of Tessore+ (2015)"""
+    t = gamma-1
+    phi_G, q = param_util.ellipticity2phi_q(e1, e2)
+    x_shift = x - center_x
+    y_shift = y - center_y
+    ang = phi_G
+    z = np.exp(-1j*phi_G) * (x_shift + y_shift*1j)
+    return z, theta_E*np.sqrt(q), t, q, ang
+
+
+@nb.generated_jit(nopython=True, cache=True)
+def nan_to_zero(x):
+    """Converts the nans in an array or scalar and returns the (overwritten) array or scalar.
+    This is necessary because of the need to support both arrays and scalars for all input functions.
+    """
+    if isinstance(x, nb.types.Array) and x.ndim > 0:
+        return nan_to_zero_arr
+    else:
+        return nan_to_zero_single
+
+@jit()
+def nan_to_zero_arr(x):
+    x[~np.isfinite(x)] = 0
+    return x
+
+@jit()
+def nan_to_zero_single(x):
+    return x if np.isfinite(x) else 0
+
+@jit()
+def alpha(x, y, b, q, t):
+    """The complex deflection angle as defined in Tessore+ (2015)"""
+    zz = x*q + 1j*y
+    R = np.abs(zz)
+    phi = np.angle(zz)
+    #if Omega is None:
+        #Omega = omega(phi, t, q)
+    Omega = omega(phi, t, q)
+    alph = (2*b)/(1+q)*(b/R)**(t-1)*Omega
+    return nan_to_zero(alph)
+
+@jit(fastmath=True) # Because of the reduction nature of this, relaxing commutativity actually matters a lot (4x speedup).
+def omega(phi, t, q, niter=200, tol=1e-16):
+    f = (1-q)/(1+q)
+    omegas = np.zeros_like(phi, dtype=np.complex128)
+    niter = min(niter, int(np.log(tol)/np.log(f))+2) # The absolute value of each summand is always less than f, hence this limit for the number of iterations.
+    Omega = 1*np.exp(1j*phi)
+    fact = -f*np.exp(2j*phi)
+    for n in range(1,niter):
+        omegas += Omega
+        Omega *= (2*n-(2-t))/(2*n+(2-t)) * fact
+    omegas += Omega
+    return omegas

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -5,7 +5,7 @@ __all__ = ['ProfileListBase']
 
 _SUPPORTED_MODELS = ['SHIFT', 'NIE_POTENTIAL', 'CONST_MAG', 'SHEAR', 'SHEAR_GAMMA_PSI', 'CONVERGENCE', 'FLEXION',
                      'FLEXIONFG', 'POINT_MASS', 'SIS', 'SIS_TRUNCATED', 'SIE', 'SPP', 'NIE', 'NIE_SIMPLE', 'CHAMELEON',
-                     'DOUBLE_CHAMELEON', 'TRIPLE_CHAMELEON', 'SPEP', 'PEMD', 'SPEMD', 'EPL', 'SPL_CORE', 'NFW', 'NFW_ELLIPSE',
+                     'DOUBLE_CHAMELEON', 'TRIPLE_CHAMELEON', 'SPEP', 'PEMD', 'SPEMD', 'EPL', 'EPL_NUMBA', 'SPL_CORE', 'NFW', 'NFW_ELLIPSE',
                      'NFW_ELLIPSE_GAUSS_DEC', 'TNFW', 'CNFW', 'CNFW_ELLIPSE', 'CTNFW_GAUSS_DEC', 'NFW_MC', 'SERSIC',
                      'SERSIC_ELLIPSE_POTENTIAL', 'SERSIC_ELLIPSE_KAPPA', 'SERSIC_ELLIPSE_GAUSS_DEC', 'PJAFFE',
                      'PJAFFE_ELLIPSE', 'HERNQUIST', 'HERNQUIST_ELLIPSE', 'GAUSSIAN', 'GAUSSIAN_KAPPA',
@@ -136,6 +136,9 @@ class ProfileListBase(object):
         elif lens_type == 'EPL':
             from lenstronomy.LensModel.Profiles.epl import EPL
             return EPL()
+        elif lens_type == 'EPL_NUMBA':
+            from lenstronomy.LensModel.Profiles.epl_numba import EPL_numba
+            return EPL_numba()
         elif lens_type == 'SPL_CORE':
             from lenstronomy.LensModel.Profiles.splcore import SPLCORE
             return SPLCORE()

--- a/lenstronomy/Util/numba_util.py
+++ b/lenstronomy/Util/numba_util.py
@@ -38,9 +38,11 @@ with open(conf_file) as file:
     fastmath = numba_conf['fastmath']
     error_model = numba_conf['error_model']
 
-#nopython = True
-#cache = True
-#parallel = False
+if numba_enabled:
+    try:
+        import numba
+    except ImportError:
+        numba_enabled = False
 
 __all__ = ['jit']
 

--- a/lenstronomy/Util/numba_util.py
+++ b/lenstronomy/Util/numba_util.py
@@ -2,7 +2,7 @@ import numba
 import lenstronomy
 import os
 import yaml
-
+import numpy as np
 
 """
 From pyautolens:
@@ -12,7 +12,6 @@ If on laptop:
 If on super computer:
 @numba.jit(nopython=True, cache=False, parallel=True)
 """
-
 
 from xdg.BaseDirectory import xdg_config_home
 
@@ -44,16 +43,58 @@ if numba_enabled:
     except ImportError:
         numba_enabled = False
 
-__all__ = ['jit']
+__all__ = ['jit', 'generated_jit']
 
 
 def jit(nopython=nopython, cache=cache, parallel=parallel, fastmath=fastmath, error_model=error_model):
     if numba_enabled:
         def wrapper(func):
-            return numba.jit(func, nopython=nopython, cache=cache, parallel=parallel, fastmath=fastmath,
-                             error_model=error_model)
+            return numba.jit(func, nopython=nopython, cache=cache, parallel=parallel,fastmath=fastmath,error_model=error_model)
     else:
         def wrapper(func):
             return func
     return wrapper
 
+def generated_jit(nopython=nopython, cache=cache, parallel=parallel,fastmath=fastmath,error_model=error_model):
+    if numba_enabled:
+        def wrapper(func):
+            return numba.generated_jit(func, nopython=nopython, cache=cache, parallel=parallel,fastmath=fastmath,error_model=error_model)
+    else:
+        def wrapper(func):
+            return func
+
+    return wrapper
+
+@generated_jit()
+def nan_to_num(x, posinf=1e10, neginf=-1e10, nan=0.):
+    """Implements an equivalent to np.nan_to_num (with copy=False!) array or scalar in Numba.
+    The generated_jit part is necessary because of the need to support both arrays and scalars for all input functions.
+    """
+    if (isinstance(x, numba.types.Array) or isinstance(x, np.ndarray)) and x.ndim > 0:
+        return nan_to_num_arr if numba_enabled else nan_to_num_arr(x, posinf, neginf, nan)
+    else:
+        return nan_to_num_single if numba_enabled else nan_to_num_single(x, posinf, neginf, nan)
+
+@jit()
+def nan_to_num_arr(x, posinf=1e10, neginf=-1e10, nan=0.):
+    for i in range(len(x)):
+        if np.isnan(x[i]):
+            x[i] = nan
+        if np.isinf(x[i]):
+            if x[i] > 0:
+                x[i]=posinf
+            else:
+                x[i]=neginf
+    return x
+
+@jit()
+def nan_to_num_single(x, posinf=1e10, neginf=-1e10, nan=0.):
+    if np.isnan(x):
+        return nan
+    elif np.isinf(x):
+        if x > 0:
+            return posinf
+        else:
+            return neginf
+    else:
+        return x

--- a/lenstronomy/Util/numba_util.py
+++ b/lenstronomy/Util/numba_util.py
@@ -49,16 +49,17 @@ __all__ = ['jit', 'generated_jit']
 def jit(nopython=nopython, cache=cache, parallel=parallel, fastmath=fastmath, error_model=error_model):
     if numba_enabled:
         def wrapper(func):
-            return numba.jit(func, nopython=nopython, cache=cache, parallel=parallel,fastmath=fastmath,error_model=error_model)
+            return numba.jit(func, nopython=nopython, cache=cache, parallel=parallel, fastmath=fastmath, error_model=error_model)
     else:
         def wrapper(func):
             return func
     return wrapper
 
-def generated_jit(nopython=nopython, cache=cache, parallel=parallel,fastmath=fastmath,error_model=error_model):
+def generated_jit(nopython=nopython, cache=cache, parallel=parallel, fastmath=fastmath, error_model=error_model):
+    """ Wrapper around numba.generated_jit. Allows you to redirect a function to another based on its type - see the Numba docs for more info"""
     if numba_enabled:
         def wrapper(func):
-            return numba.generated_jit(func, nopython=nopython, cache=cache, parallel=parallel,fastmath=fastmath,error_model=error_model)
+            return numba.generated_jit(func, nopython=nopython, cache=cache, parallel=parallel, fastmath=fastmath, error_model=error_model)
     else:
         def wrapper(func):
             return func
@@ -67,9 +68,11 @@ def generated_jit(nopython=nopython, cache=cache, parallel=parallel,fastmath=fas
 
 @generated_jit()
 def nan_to_num(x, posinf=1e10, neginf=-1e10, nan=0.):
-    """Implements an equivalent to np.nan_to_num (with copy=False!) array or scalar in Numba.
-    The generated_jit part is necessary because of the need to support both arrays and scalars for all input functions.
     """
+    Implements a Numba equivalent to np.nan_to_num (with copy=False!) array or scalar in Numba.
+    Behaviour is the same as np.nan_to_num with copy=False, although it only supports 1-dimensional arrays and scalar inputs.
+    """
+    # The generated_jit part is necessary because of the need to support both arrays and scalars for all input functions.
     if (isinstance(x, numba.types.Array) or isinstance(x, np.ndarray)) and x.ndim > 0:
         return nan_to_num_arr if numba_enabled else nan_to_num_arr(x, posinf, neginf, nan)
     else:
@@ -77,6 +80,7 @@ def nan_to_num(x, posinf=1e10, neginf=-1e10, nan=0.):
 
 @jit()
 def nan_to_num_arr(x, posinf=1e10, neginf=-1e10, nan=0.):
+    """Part of the Numba implementation of np.nan_to_num - see nan_to_num"""
     for i in range(len(x)):
         if np.isnan(x[i]):
             x[i] = nan
@@ -89,6 +93,7 @@ def nan_to_num_arr(x, posinf=1e10, neginf=-1e10, nan=0.):
 
 @jit()
 def nan_to_num_single(x, posinf=1e10, neginf=-1e10, nan=0.):
+    """Part of the Numba implementation of np.nan_to_num - see nan_to_num"""
     if np.isnan(x):
         return nan
     elif np.isinf(x):

--- a/lenstronomy/Util/param_util.py
+++ b/lenstronomy/Util/param_util.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from lenstronomy.Util.package_util import exporter
-from lenstronomy.Util.numba_util import jit
 export, __all__ = exporter()
 
 

--- a/lenstronomy/Util/param_util.py
+++ b/lenstronomy/Util/param_util.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from lenstronomy.Util.package_util import exporter
+from lenstronomy.Util.numba_util import jit
 export, __all__ = exporter()
 
 
@@ -69,6 +70,7 @@ def shear_cartesian2polar(gamma1, gamma2):
 
 
 @export
+@jit()
 def phi_q2_ellipticity(phi, q):
     """
     transforms orientation angle and axis ratio into complex ellipticity moduli e1, e2
@@ -83,6 +85,7 @@ def phi_q2_ellipticity(phi, q):
 
 
 @export
+@jit()
 def ellipticity2phi_q(e1, e2):
     """
     transforms complex ellipticity moduli in orientation angle and axis ratio

--- a/lenstronomy/Util/param_util.py
+++ b/lenstronomy/Util/param_util.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from lenstronomy.Util.numba_util import jit
 from lenstronomy.Util.package_util import exporter
 export, __all__ = exporter()
 

--- a/test/test_LensModel/test_Profiles/test_epl_numba.py
+++ b/test/test_LensModel/test_Profiles/test_epl_numba.py
@@ -94,15 +94,21 @@ class TestEPL_numba(object):
         phi_G = 1.
         e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
 
-        #x = 0.
-        #y = 0.
-        #f_x, f_y = self.EPL_numba.derivatives(x, y, phi_E, e1, e2, gamma)
-        #npt.assert_almost_equal(f_x, 0.)
-        #npt.assert_almost_equal(f_y, 0.)
+        x = 0.
+        y = 0.
+        f_x, f_y = self.EPL_numba.derivatives(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f_x, 0.)
+        npt.assert_almost_equal(f_y, 0.)
 
         x = 0.
         y = 0.
         f_x, f_y = self.EPL.derivatives(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f_x, 0.)
+        npt.assert_almost_equal(f_y, 0.)
+
+        x = 0.
+        y = 0.
+        f_x, f_y = self.EPL.derivatives(x, y, phi_E, e1, e2, gamma+0.1)
         npt.assert_almost_equal(f_x, 0.)
         npt.assert_almost_equal(f_y, 0.)
 

--- a/test/test_LensModel/test_Profiles/test_epl_numba.py
+++ b/test/test_LensModel/test_Profiles/test_epl_numba.py
@@ -1,0 +1,121 @@
+__author__ = 'sibirrer'
+
+
+import numpy as np
+import pytest
+import numpy.testing as npt
+import lenstronomy.Util.param_util as param_util
+
+
+class TestEPL_numba(object):
+    """
+    tests the Gaussian methods
+    """
+    def setup(self):
+        from lenstronomy.LensModel.Profiles.epl import EPL
+        self.EPL = EPL()
+        from lenstronomy.LensModel.Profiles.epl_numba import EPL_numba
+        self.EPL_numba = EPL_numba()
+
+    def test_function(self):
+        phi_E = 1.
+        gamma = 2.
+        q = 0.999
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        x = np.array([1., 2])
+        y = np.array([2, 0])
+        values = self.EPL.function(x, y, phi_E, e1, e2, gamma)
+        values_nb = self.EPL_numba.function(x, y, phi_E, e1, e2, gamma)
+        delta_f = values[0] - values[1]
+        delta_f_nb = values_nb[0] - values_nb[1]
+        npt.assert_almost_equal(delta_f, delta_f_nb, decimal=10)
+
+        q = 0.8
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        x = np.array([1., 2])
+        y = np.array([2, 0])
+        values = self.EPL.function(x, y, phi_E, e1, e2, gamma)
+        values_nb = self.EPL_numba.function(x, y, phi_E, e1, e2, gamma)
+        delta_f = values[0] - values[1]
+        delta_f_nb = values_nb[0] - values_nb[1]
+        npt.assert_almost_equal(delta_f, delta_f_nb, decimal=10)
+
+        q = 0.4
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        x = np.array([1., 2])
+        y = np.array([2, 0])
+        values = self.EPL.function(x, y, phi_E, e1, e2, gamma)
+        values_nb = self.EPL_numba.function(x, y, phi_E, e1, e2, gamma)
+        delta_f = values[0] - values[1]
+        delta_f_nb = values_nb[0] - values_nb[1]
+        npt.assert_almost_equal(delta_f, delta_f_nb, decimal=10)
+
+    def test_derivatives(self):
+        x = np.array([1])
+        y = np.array([2])
+        phi_E = 1.
+        gamma = 1.8
+        q = 1.
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        f_x, f_y = self.EPL.derivatives(x, y, phi_E, e1, e2, gamma)
+        f_x_nb, f_y_nb = self.EPL_numba.derivatives(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f_x, f_x_nb, decimal=10)
+        npt.assert_almost_equal(f_y, f_y_nb, decimal=10)
+
+        q = 0.7
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        f_x, f_y = self.EPL.derivatives(x, y, phi_E, e1, e2, gamma)
+        f_x_nb, f_y_nb = self.EPL_numba.derivatives(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f_x, f_x_nb, decimal=10)
+        npt.assert_almost_equal(f_y, f_y_nb, decimal=10)
+
+    def test_hessian(self):
+        x = np.array([1.])
+        y = np.array([2.])
+        phi_E = 1.
+        gamma = 2.2
+        q = 0.9
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+        f_xx, f_yy,f_xy = self.EPL.hessian(x, y, phi_E, e1, e2, gamma)
+        f_xx_nb, f_yy_nb, f_xy_nb = self.EPL_numba.hessian(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f_xx, f_xx_nb, decimal=10)
+        npt.assert_almost_equal(f_yy, f_yy_nb, decimal=10)
+        npt.assert_almost_equal(f_xy, f_xy_nb, decimal=10)
+
+    def test_regularization(self):
+
+        phi_E = 1.
+        gamma = 2.
+        q = 1.
+        phi_G = 1.
+        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
+
+        #x = 0.
+        #y = 0.
+        #f_x, f_y = self.EPL_numba.derivatives(x, y, phi_E, e1, e2, gamma)
+        #npt.assert_almost_equal(f_x, 0.)
+        #npt.assert_almost_equal(f_y, 0.)
+
+        x = 0.
+        y = 0.
+        f_x, f_y = self.EPL.derivatives(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f_x, 0.)
+        npt.assert_almost_equal(f_y, 0.)
+
+        x = 0.
+        y = 0.
+        f = self.EPL_numba.function(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f, 0.)
+
+        x = 0.
+        y = 0.
+        f_xx, f_xy, f_yy = self.EPL_numba.hessian(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(1/((1-f_xx)*(1-f_yy)-f_xy**2), 0., decimal=10)
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/test/test_LensModel/test_Profiles/test_epl_numba.py
+++ b/test/test_LensModel/test_Profiles/test_epl_numba.py
@@ -114,6 +114,10 @@ class TestEPL_numba(object):
         x = 0.
         y = 0.
         f_xx, f_xy, f_yy = self.EPL_numba.hessian(x, y, phi_E, e1, e2, gamma)
+        npt.assert_almost_equal(f_xx, 1e10, decimal=10)
+        npt.assert_almost_equal(f_xy, 0, decimal=10)
+        npt.assert_almost_equal(f_yy, 0, decimal=5) # floating point cancellation, so less precise
+        # Magnification:
         npt.assert_almost_equal(1/((1-f_xx)*(1-f_yy)-f_xy**2), 0., decimal=10)
 
 

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -266,6 +266,11 @@ class TestNumericsProfile(object):
         lens_model = ['EPL']
         self.assert_differentials(lens_model, kwargs)
 
+    def test_EPL_numba(self):
+        kwargs = {'theta_E': 2., 'e1': 0.1, 'e2': 0., 'gamma': 2.13}
+        lens_model = ['EPL']
+        self.assert_differentials(lens_model, kwargs)
+
     def test_coreBurk(self):
         kwargs = {'Rs':2, 'alpha_Rs': 1, 'r_core':0.4}
         lens_model = ['coreBURKERT']

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -268,7 +268,7 @@ class TestNumericsProfile(object):
 
     def test_EPL_numba(self):
         kwargs = {'theta_E': 2., 'e1': 0.1, 'e2': 0., 'gamma': 2.13}
-        lens_model = ['EPL']
+        lens_model = ['EPL_NUMBA']
         self.assert_differentials(lens_model, kwargs)
 
     def test_coreBurk(self):


### PR DESCRIPTION
This is the same profile as the already existing EPL profile, but my own implementation of it with Numba. Numba code is never pretty, but it is quite a bit faster than the existing PEMD models. Timings:
https://gist.github.com/ewoudwempe/10d47a7433afdb4d750dfad29e8dcd95
Comments? I suppose I'll have to make some tests too...
I could cache the parameter conversions, but it is a very small part of the computation times, so I don't think it's worth it.