### PR TITLE
Master2main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,11 @@ Finally add the `lenstronomy` repository as a *remote*. This will allow you to f
 
 ### Create a branch for your new feature
 
-Create a *branch* off the `lenstronomyproject` master branch. Working on unique branches for each new feature simplifies the development, review and merge processes by maintining logical separation. To create a feature branch:
+Create a *branch* off the `lenstronomyproject` main branch. Working on unique branches for each new feature simplifies the development, review and merge processes by maintining logical separation. To create a feature branch:
 
   ```bash
   git fetch lenstronomyproject
-  git checkout -b <your-branch-name> lenstronomyproject/master
+  git checkout -b <your-branch-name> lenstronomyproject/main
   ```
 
 ### Hack away!
@@ -63,26 +63,26 @@ When you feel that work on your new feature is complete, you should create a *Pu
   1. Go to [lenstronomy Pull Requests](https://github.com/sibirrer/lenstronomy/pulls)
   2. Click the green **New pull request** button
   3. Click **compare across forks**
-  4. Confirm that the base fork is `sibirrer/lenstronomy` and the base branch is `master`
+  4. Confirm that the base fork is `sibirrer/lenstronomy` and the base branch is `main`
   5. Confirm the head fork is `<your-account>/lenstronomy` and the compare branch is `<your-branch-name>`
   6. Give your pull request a title and fill out the the template for the description
   7. Click the green **Create pull request** button
 
 ### Updating your branch
 
-As you work on your feature, new commits might be made to the `sibirrer/lenstronomy` master branch. You will need to update your branch with these new commits before your pull request can be accepted. You can achieve this in a few different ways:
+As you work on your feature, new commits might be made to the `sibirrer/lenstronomy` main branch. You will need to update your branch with these new commits before your pull request can be accepted. You can achieve this in a few different ways:
 
   - If your pull request has no conflicts, click **Update branch**
   - If your pull request has conflicts, click **Resolve conflicts**, manually resolve the conflicts and click **Mark as resolved**
-  - *merge* the `lenstronomyproject` master branch from the command line:
+  - *merge* the `lenstronomyproject` main branch from the command line:
     ```bash
     git fetch lenstronomyproject
-    git merge lenstronomyproject/master
+    git merge lenstronomyproject/main
     ```
-  - *rebase* your feature branch onto the `lenstronomy` master branch from the command line:
+  - *rebase* your feature branch onto the `lenstronomy` main branch from the command line:
     ```bash
     git fetch lenstronomyproject
-    git rebase lenstronomyproject/master
+    git rebase lenstronomyproject/main
     ```
 
 **Warning**: It is bad practice to *rebase* commits that have already been pushed to a remote such as your fork. Rebasing creates new copies of your commits that can cause the local and remote branches to diverge. `git push --force` will **overwrite** the remote branch with your newly rebased local branch. This is strongly discouraged, particularly when working on a shared branch where you could erase a collaborators commits.
@@ -125,4 +125,4 @@ All public classes, methods and functions require docstrings. You can build docu
 
 For more information see the Astropy guide to [Writing Documentation](https://docs.astropy.org/en/stable/development/docguide.html).
 
-This page is inspired by the Contributions guidelines of the [Skypy project](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md).
+This page is inspired by the Contributions guidelines of the [Skypy project](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.md).

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ lenstronomy - gravitational lensing software package
         :target: https://coveralls.io/github/sibirrer/lenstronomy?branch=main
 
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg?style=flat
-    :target: https://github.com/sibirrer/lenstronomy/blob/master/LICENSE
+    :target: https://github.com/sibirrer/lenstronomy/blob/main/LICENSE
 
 .. image:: https://img.shields.io/badge/arXiv-1803.09746%20-yellowgreen.svg
     :target: https://arxiv.org/abs/1803.09746

--- a/README.rst
+++ b/README.rst
@@ -7,15 +7,15 @@ lenstronomy - gravitational lensing software package
 .. image:: https://badge.fury.io/py/lenstronomy.png
     :target: https://badge.fury.io/py/lenstronomy
 
-.. image:: https://travis-ci.org/sibirrer/lenstronomy.png?branch=master
+.. image:: https://travis-ci.org/sibirrer/lenstronomy.png?branch=main
         :target: https://travis-ci.org/sibirrer/lenstronomy
 
 .. image:: https://readthedocs.org/projects/lenstronomy/badge/?version=latest
         :target: http://lenstronomy.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://coveralls.io/repos/github/sibirrer/lenstronomy/badge.svg?branch=master
-        :target: https://coveralls.io/github/sibirrer/lenstronomy?branch=master
+.. image:: https://coveralls.io/repos/github/sibirrer/lenstronomy/badge.svg?branch=main
+        :target: https://coveralls.io/github/sibirrer/lenstronomy?branch=main
 
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg?style=flat
     :target: https://github.com/sibirrer/lenstronomy/blob/master/LICENSE
@@ -32,7 +32,7 @@ lenstronomy - gravitational lensing software package
 ``lenstronomy`` finds application for time-delay cosmography and measuring
 the expansion rate of the universe, for quantifying lensing substructure to infer dark matter properties, morphological quantification of galaxies,
 quasar-host galaxy decomposition and much more.
-A (incomplete) list of publications making use of lenstronomy can be found `at this link <https://github.com/sibirrer/lenstronomy/blob/master/PUBLISHED.rst>`_.
+A (incomplete) list of publications making use of lenstronomy can be found `at this link <https://github.com/sibirrer/lenstronomy/blob/main/PUBLISHED.rst>`_.
 
 
 The development is coordinated on `GitHub <https://github.com/sibirrer/lenstronomy>`_ and contributions are welcome.
@@ -58,7 +58,7 @@ we refer to the `documentation <https://lenstronomy.readthedocs.io/en/latest/ins
 Getting started
 ---------------
 
-The `starting guide jupyter notebook <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/starting_guide.ipynb>`_
+The `starting guide jupyter notebook <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/starting_guide.ipynb>`_
 leads through the main modules and design features of ``lenstronomy``. The modular design of ``lenstronomy`` allows the
 user to directly access a lot of tools and each module can also be used as stand-alone packages.
 
@@ -69,24 +69,24 @@ Example notebooks
 We have made an extension module available at `https://github.com/sibirrer/lenstronomy_extensions <https://github.com/sibirrer/lenstronomy_extensions>`_.
 You can find simple examle notebooks for various cases. The latest versions of the notebooks should be compatible with the recent pip version of lenstronomy.
 
-* `Units, coordinate system and parameter definitions in lenstronomy <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/units_coordinates_parameters.ipynb>`_
-* `FITS handling and extracting needed information from the data prior to modeling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/fits_handling.ipynb>`_
-* `Modeling a simple Einstein ring <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/simple_ring.ipynb>`_
-* `Quadrupoly lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/quad_model.ipynb>`_
-* `Double lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/double_model.ipynb>`_
-* `Time-delay cosmography <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/time-delay%20cosmography.ipynb>`_
-* `Source reconstruction and deconvolution with Shapelets <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/shapelet_source_modelling.ipynb>`_
-* `Solving the lens equation <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/lens_equation.ipynb>`_
-* `Multi-band fitting <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/multi_band_fitting.ipynb>`_
-* `Measuring cosmic shear with Einstein rings <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/EinsteinRingShear_simulations.ipynb>`_
-* `Fitting of galaxy light profiles, like e.g. GALFIT <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/galfitting.ipynb>`_
-* `Quasar-host galaxy decomposition <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/quasar-host%20decomposition.ipynb>`_
-* `Hiding and seeking a single subclump <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/substructure_challenge_simple.ipynb>`_
-* `Mock generation of realistic images with substructure in the lens <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/substructure_challenge_mock_production.ipynb>`_
-* `Mock simulation API with multi color models <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/simulation_api.ipynb>`_
-* `Catalogue data modeling of image positions, flux ratios and time delays <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/catalogue%20modelling.ipynb>`_
-* `Example of numerical ray-tracing and convolution options <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/lenstronomy_numerics.ipynb>`_
-* `Simulated lenses with populations generated by SkyPy <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/skypy_lenstronomy.ipynb>`_
+* `Units, coordinate system and parameter definitions in lenstronomy <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/units_coordinates_parameters.ipynb>`_
+* `FITS handling and extracting needed information from the data prior to modeling <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/fits_handling.ipynb>`_
+* `Modeling a simple Einstein ring <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/simple_ring.ipynb>`_
+* `Quadrupoly lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/quad_model.ipynb>`_
+* `Double lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/double_model.ipynb>`_
+* `Time-delay cosmography <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/time-delay%20cosmography.ipynb>`_
+* `Source reconstruction and deconvolution with Shapelets <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/shapelet_source_modelling.ipynb>`_
+* `Solving the lens equation <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/lens_equation.ipynb>`_
+* `Multi-band fitting <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/multi_band_fitting.ipynb>`_
+* `Measuring cosmic shear with Einstein rings <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/EinsteinRingShear_simulations.ipynb>`_
+* `Fitting of galaxy light profiles, like e.g. GALFIT <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/galfitting.ipynb>`_
+* `Quasar-host galaxy decomposition <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/quasar-host%20decomposition.ipynb>`_
+* `Hiding and seeking a single subclump <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/substructure_challenge_simple.ipynb>`_
+* `Mock generation of realistic images with substructure in the lens <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/substructure_challenge_mock_production.ipynb>`_
+* `Mock simulation API with multi color models <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/simulation_api.ipynb>`_
+* `Catalogue data modeling of image positions, flux ratios and time delays <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/catalogue%20modelling.ipynb>`_
+* `Example of numerical ray-tracing and convolution options <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/lenstronomy_numerics.ipynb>`_
+* `Simulated lenses with populations generated by SkyPy <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/skypy_lenstronomy.ipynb>`_
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
+# The main toctree document.
 master_doc = 'index'
 
 # General information about the project.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ You can also clone the github repository for development purposes.
 Requirements
 ------------
 
-Make sure the standard python libraries as specified in the `requirements <https://github.com/sibirrer/lenstronomy/blob/master/requirements.txt>`_.
+Make sure the standard python libraries as specified in the `requirements <https://github.com/sibirrer/lenstronomy/blob/main/requirements.txt>`_.
 The standard usage does not require all libraries to be installed, in particluar the different posterior samplers are only required when being used.
 
 In the following, a few specific cases are mentioned that may require special attention in the installation and settings, in particular when it comes
@@ -28,7 +28,7 @@ MPI
 ---
 MPI support is provided for several sampling techniques for parallel computing. A specific version of the library schwimmbad is required
 for the correct support of the moving of the likelihood elements from one processor to another with MPI. Pay attention ot the
-`requirements <https://github.com/sibirrer/lenstronomy/blob/master/requirements.txt>`_.
+`requirements <https://github.com/sibirrer/lenstronomy/blob/main/requirements.txt>`_.
 
 
 NUMBA
@@ -37,7 +37,7 @@ Just-in-time (jit) compilation with numba can provide significant speed-up for c
 There are specific settings for the settings provided as per default, but these may need to be adopted when running on a HPC cluster.
 You can define your own configuration file in your $XDG_CONFIG_HOME/lenstronomy/config.yaml file. E.g. (check your system for the path)
  ~/.conf/lenstronomy/config.yaml, following the format of the
-default configuration which is `here <https://github.com/sibirrer/lenstronomy/blob/master/lenstronomy/Conf/conf_default.yaml>`_.
+default configuration which is `here <https://github.com/sibirrer/lenstronomy/blob/main/lenstronomy/Conf/conf_default.yaml>`_.
 
 
 FASTELL

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,7 +9,7 @@ To use lenstronomy in a project::
 Getting started
 ---------------
 
-The `starting guide jupyter notebook <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/starting_guide.ipynb>`_
+The `starting guide jupyter notebook <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/starting_guide.ipynb>`_
 leads through the main modules and design features of **lenstronomy**. The modular design of **lenstronomy** allows the
 user to directly access a lot of tools and each module can also be used as stand-alone packages.
 
@@ -20,18 +20,22 @@ Example notebooks
 We have made an extension module available at `https://github.com/sibirrer/lenstronomy_extensions <https://github.com/sibirrer/lenstronomy_extensions>`_.
 You can find simple examle notebooks for various cases. The latest versions of the notebooks should be compatible with the recent pip version of lenstronomy.
 
-* `Units, coordiante system and parameter definitions in lenstronomy <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/units_coordinates_parameters.ipynb>`_
-* `FITS handling and extracting needed information from the data prior to modeling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/units_coordinates_parameters.ipynb>`_
-* `Quadrupoly lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/quad_model.ipynb>`_
-* `Double lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/double_model.ipynb>`_
-* `Time-delay cosmography <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/time-delay%20cosmography.ipynb>`_
-* `Source reconstruction and deconvolution with Shapelets <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/shapelet_source_modelling.ipynb>`_
-* `Solving the lens equation <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/lens_equation.ipynb>`_
-* `Measuring cosmic shear with Einstein rings <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/EinsteinRingShear_simulations.ipynb>`_
-* `Fitting of galaxy light profiles, like e.g. GALFIT <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/galfitting.ipynb>`_
-* `Quasar-host galaxy decomposition <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/quasar-host%20decomposition.ipynb>`_
-* `Hiding and seeking a single subclump <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/substructure_challenge_simple.ipynb>`_
-* `Mock generation of realistic images with substructure in the lens <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/substructure_challenge_mock_production.ipynb>`_
-* `Mock simulation API with multi color models <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/simulation_api.ipynb>`_
-* `Catalogue data modeling of image positions, flux ratios and time delays <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/catalogue%20modelling.ipynb>`_
-* `Example of numerical ray-tracing and convolution options <https://github.com/sibirrer/lenstronomy_extensions/blob/master/lenstronomy_extensions/Notebooks/lenstronomy_numerics.ipynb>`_
+* `Units, coordinate system and parameter definitions in lenstronomy <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/units_coordinates_parameters.ipynb>`_
+* `FITS handling and extracting needed information from the data prior to modeling <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/fits_handling.ipynb>`_
+* `Modeling a simple Einstein ring <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/simple_ring.ipynb>`_
+* `Quadrupoly lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/quad_model.ipynb>`_
+* `Double lensed quasar modelling <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/double_model.ipynb>`_
+* `Time-delay cosmography <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/time-delay%20cosmography.ipynb>`_
+* `Source reconstruction and deconvolution with Shapelets <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/shapelet_source_modelling.ipynb>`_
+* `Solving the lens equation <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/lens_equation.ipynb>`_
+* `Multi-band fitting <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/multi_band_fitting.ipynb>`_
+* `Measuring cosmic shear with Einstein rings <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/EinsteinRingShear_simulations.ipynb>`_
+* `Fitting of galaxy light profiles, like e.g. GALFIT <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/galfitting.ipynb>`_
+* `Quasar-host galaxy decomposition <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/quasar-host%20decomposition.ipynb>`_
+* `Hiding and seeking a single subclump <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/substructure_challenge_simple.ipynb>`_
+* `Mock generation of realistic images with substructure in the lens <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/substructure_challenge_mock_production.ipynb>`_
+* `Mock simulation API with multi color models <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/simulation_api.ipynb>`_
+* `Catalogue data modeling of image positions, flux ratios and time delays <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/catalogue%20modelling.ipynb>`_
+* `Example of numerical ray-tracing and convolution options <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/lenstronomy_numerics.ipynb>`_
+* `Simulated lenses with populations generated by SkyPy <https://github.com/sibirrer/lenstronomy_extensions/blob/main/lenstronomy_extensions/Notebooks/skypy_lenstronomy.ipynb>`_
+


### PR DESCRIPTION
The main branch of lenstronomy and lenstronomy_extensions have been renamed from previously 'master' to 'main' this PR is to make sure all the links and descriptions are pointing towards the new name.

For developer: 
The following local commands allow you to re-base origin.

$git branch -m master main
$git fetch origin
$git branch -u origin/main main

This remaining is inspired by https://jarv.is/notes/github-rename-master/
GitHub made it since more convenient to rename existing branches and this re-naming followed https://github.com/github/renaming