### PR TITLE
Vectorize LightModel.Interpol's interpolation

### DIFF
--- a/lenstronomy/LightModel/Profiles/interpolation.py
+++ b/lenstronomy/LightModel/Profiles/interpolation.py
@@ -40,16 +40,8 @@ class Interpol(object):
         :param scale: pixel scale (in angular units) of the simulated image
         :return: surface brightness from the model at coordinates (x, y)
         """
-        n = len(np.atleast_1d(x))
         x_, y_ = self.coord2image_pixel(x, y, center_x, center_y, phi_G, scale)
-        if n <= 1 and np.shape(x) == ():
-            f_out = self.image_interp(x_, y_, image)
-            return f_out[0][0] * amp
-        else:
-            f_out = np.zeros(n)
-            for i in range(n):
-                f_out[i] = self.image_interp(x_[i], y_[i], image)
-        return f_out * amp
+        return amp * self.image_interp(x_, y_, image)
 
     def image_interp(self, x, y, image):
         if not hasattr(self, '_image_interp'):
@@ -66,7 +58,7 @@ class Interpol(object):
 
         # y and x must be flipped in call to interpolator
         # (try reversing, the unit tests will fail)
-        return self._image_interp(y, x)
+        return self._image_interp(y, x, grid=False)
 
     def total_flux(self, image, scale, amp=1, center_x=0, center_y=0, phi_G=0):
         """

--- a/test/test_LightModel/test_Profiles/test_interpolation.py
+++ b/test/test_LightModel/test_Profiles/test_interpolation.py
@@ -47,6 +47,9 @@ class TestInterpol(object):
         out_shift = interp.function(x=1, y=0, image=image, scale=1., phi_G=0, center_x=1, center_y=0)
         assert out_shift == out
 
+        # function must give a single value when evaluated at a single point
+        assert isinstance(out, float)
+
         # test change of scale without re-doing interpolation
         out = interp.function(x=1., y=0, image=image, scale=1., phi_G=0, center_x=0, center_y=0)
         out_scaled = interp.function(x=2., y=0, image=image, scale=2, phi_G=0, center_x=0, center_y=0)


### PR DESCRIPTION
This uses the grid=False option to scipy [`scipy.interpolate.RectBivariateSpline.__call__`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RectBivariateSpline.__call__.html) to simplify and speed up the `Interpol` light model. 

In simple examples (where lensing or other calculations are not the limiting factor), this can give a significant speedup to image generation. I got a factor ~5 improvement in a simple case with only an SIS and a tNFW lens. The interpolation itself speeds up by about 20x for a 125x125 pixel image.

(I guess the coverage decrease is because this shortens already-tested code?)