### PR TITLE
Fix identity checks that trigger SyntaxWarning on python 3.8

### DIFF
--- a/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
@@ -41,7 +41,7 @@ class FluxRatioLikelihood(object):
         :param kwargs_cosmo:
         :return: log likelihood of the measured flux ratios given a model
         """
-        if self._source_type is 'INF':
+        if self._source_type == 'INF':
             mag = np.abs(self._lens_model_class.magnification(x_pos, y_pos, kwargs_lens))
         else:
             source_sigma = kwargs_cosmo['source_size']

--- a/lenstronomy/Workflow/fitting_sequence.py
+++ b/lenstronomy/Workflow/fitting_sequence.py
@@ -226,7 +226,7 @@ class FittingSequence(object):
         else:
             initpos = None
 
-        if sampler_type is 'EMCEE':
+        if sampler_type == 'EMCEE':
             n_walkers = num_param * walkerRatio
             samples, dist = mcmc_class.mcmc_emcee(n_walkers, n_run, n_burn, mean_start, sigma_start, mpi=self._mpi,
                                                   threadCount=threadCount, progress=progress, initpos=initpos,


### PR DESCRIPTION
This extremely minor PR fixes  two identity comparisons that [trigger a `SyntaxWarning`](https://bugs.python.org/issue34850) at import time, at least on some python versions since 3.8 (in some circumstances).
```
/sdf/home/j/jaalbers/software/lenstronomy/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py:44: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self._source_type is 'INF':
/sdf/home/j/jaalbers/software/lenstronomy/lenstronomy/Workflow/fitting_sequence.py:229: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if sampler_type is 'EMCEE':
```
