### PR TITLE
JOSS paper: expand names where necessary

### DIFF
--- a/Paper/paper.bib
+++ b/Paper/paper.bib
@@ -38,7 +38,7 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{Nightingale:2021,
-       author = {{Nightingale}, James and {Hayes}, Richard and {Kelly}, Ashley and {Amvrosiadis}, Aristeidis and {Etherington}, Amy and {He}, Qiuhan and {Li}, Nan and {Cao}, XiaoYue and {Frawley}, Jonathan and {Cole}, Shaun and {Enia}, Andrea and {Frenk}, Carlos and {Harvey}, David and {Li}, Ran and {Massey}, Richard and {Negrello}, Mattia and {Robertson}, Andrew},
+       author = {{Nightingale}, James W. and {Hayes}, Richard and {Kelly}, Ashley and {Amvrosiadis}, Aristeidis and {Etherington}, Amy and {He}, Qiuhan and {Li}, Nan and {Cao}, XiaoYue and {Frawley}, Jonathan and {Cole}, Shaun and {Enia}, Andrea and {Frenk}, Carlos and {Harvey}, David and {Li}, Ran and {Massey}, Richard and {Negrello}, Mattia and {Robertson}, Andrew},
         title = "{PyAutoLens: Open-Source Strong Gravitational Lensing}",
       journal = {The Journal of Open Source Software},
      keywords = {Python, astronomy, galaxies, gravitational lensing, cosmology},
@@ -87,7 +87,7 @@ archivePrefix = {ascl},
 
 
 @ARTICLE{Nightingale:2018,
-       author = {{Nightingale}, J.~W. and {Dye}, S. and {Massey}, Richard J.},
+       author = {{Nightingale}, James W. and {Dye}, S. and {Massey}, Richard J.},
         title = "{AutoLens: automated modeling of a strong lens's light, mass, and source}",
       journal = {MNRAS},
      keywords = {gravitational lensing, galaxy: structure, methods: data analysis, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
@@ -257,7 +257,7 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{Joseph:2019,
-       author = {{Joseph}, R. and {Courbin}, F. and {Starck}, J. -L. and {Birrer}, S.},
+       author = {{Joseph}, R. and {Courbin}, F. and {Starck}, J. -L. and {Birrer}, Simon},
         title = "{Sparse Lens Inversion Technique (SLIT): lens and source separability from linear inversion of the source reconstruction problem}",
       journal = {Astronomy & Astrophysics},
      keywords = {gravitational lensing: strong, methods: data analysis, techniques: image processing, galaxies: high-redshift, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
@@ -314,7 +314,7 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{Ding:2021tdlmc,
-       author = {{Ding}, X. and {Treu}, T. and {Birrer}, S. and {Chen}, G.~C. -F. and {Coles}, J. and {Denzel}, P. and {Frigo}, M. and {Galan}, A. and {Marshall}, P.~J. and {Millon}, M. and {More}, A. and {Shajib}, A.~J. and {Sluse}, D. and {Tak}, H. and {Xu}, D. and {Auger}, M.~W. and {Bonvin}, V. and {Chand}, H. and {Courbin}, F. and {Despali}, G. and {Fassnacht}, C.~D. and {Gilman}, D. and {Hilbert}, S. and {Kumar}, S.~R. and {Lin}, J.~Y. -Y. and {Park}, J.~W. and {Saha}, P. and {Vegetti}, S. and {Van de Vyvere}, L. and {Williams}, L.~L.~R.},
+       author = {{Ding}, Xuheng and {Treu}, T. and {Birrer}, Simon and {Chen}, G.~C. -F. and {Coles}, J. and {Denzel}, P. and {Frigo}, M. and {Galan}, A. and {Marshall}, P.~J. and {Millon}, M. and {More}, A. and {Shajib}, Anowar J. and {Sluse}, D. and {Tak}, H. and {Xu}, D. and {Auger}, M.~W. and {Bonvin}, V. and {Chand}, H. and {Courbin}, F. and {Despali}, G. and {Fassnacht}, C.~D. and {Gilman}, D. and {Hilbert}, S. and {Kumar}, S.~R. and {Lin}, J.~Y. -Y. and {Park}, J.~W. and {Saha}, P. and {Vegetti}, S. and {Van de Vyvere}, L. and {Williams}, L.~L.~R.},
         title = "{Time delay lens modelling challenge}",
       journal = {Monthly Notices of the Royal Astronomical Society},
      keywords = {gravitational lensing: strong, methods: data analysis, cosmology: observations, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
@@ -394,7 +394,7 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{Millon:2020,
-       author = {{Millon}, M. and {Galan}, A. and {Courbin}, F. and {Treu}, T. and {Suyu}, S.~H. and {Ding}, X. and {Birrer}, S. and {Chen}, G.~C. -F. and {Shajib}, A.~J. and {Sluse}, D. and {Wong}, K.~C. and {Agnello}, A. and {Auger}, M.~W. and {Buckley-Geer}, E.~J. and {Chan}, J.~H.~H. and {Collett}, T. and {Fassnacht}, C.~D. and {Hilbert}, S. and {Koopmans}, L.~V.~E. and {Motta}, V. and {Mukherjee}, S. and {Rusu}, C.~E. and {Sonnenfeld}, A. and {Spiniello}, C. and {Van de Vyvere}, L.},
+       author = {{Millon}, M. and {Galan}, A. and {Courbin}, F. and {Treu}, T. and {Suyu}, S.~H. and {Ding}, Xuheng and {Birrer}, Simon and {Chen}, G.~C. -F. and {Shajib}, Anowar J. and {Sluse}, D. and {Wong}, K.~C. and {Agnello}, A. and {Auger}, M.~W. and {Buckley-Geer}, E.~J. and {Chan}, J.~H.~H. and {Collett}, T. and {Fassnacht}, C.~D. and {Hilbert}, S. and {Koopmans}, L.~V.~E. and {Motta}, V. and {Mukherjee}, S. and {Rusu}, C.~E. and {Sonnenfeld}, A. and {Spiniello}, C. and {Van de Vyvere}, L.},
         title = "{TDCOSMO. I. An exploration of systematic uncertainties in the inference of H$_{0}$ from time-delay cosmography}",
       journal = {Astronomy & Astrophysics},
      keywords = {gravitational lensing: strong, methods: data analysis, Astrophysics - Cosmology and Nongalactic Astrophysics},
@@ -490,7 +490,7 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{Shajib:2019,
-       author = {{Shajib}, A.~J. and {Birrer}, S. and {Treu}, T. and {Auger}, M.~W. and {Agnello}, A. and {Anguita}, T. and {Buckley-Geer}, E.~J. and {Chan}, J.~H.~H. and {Collett}, T.~E. and {Courbin}, F. and {Fassnacht}, C.~D. and {Frieman}, J. and {Kayo}, I. and {Lemon}, C. and {Lin}, H. and {Marshall}, P.~J. and {McMahon}, R. and {More}, A. and {Morgan}, N.~D. and {Motta}, V. and {Oguri}, M. and {Ostrovski}, F. and {Rusu}, C.~E. and {Schechter}, P.~L. and {Shanks}, T. and {Suyu}, S.~H. and {Meylan}, G. and {Abbott}, T.~M.~C. and {Allam}, S. and {Annis}, J. and {Avila}, S. and {Bertin}, E. and {Brooks}, D. and {Carnero Rosell}, A. and {Carrasco Kind}, M. and {Carretero}, J. and {Cunha}, C.~E. and {da Costa}, L.~N. and {De Vicente}, J. and {Desai}, S. and {Doel}, P. and {Flaugher}, B. and {Fosalba}, P. and {Garc{\'\i}a-Bellido}, J. and {Gerdes}, D.~W. and {Gruen}, D. and {Gruendl}, R.~A. and {Gutierrez}, G. and {Hartley}, W.~G. and {Hollowood}, D.~L. and {Hoyle}, B. and {James}, D.~J. and {Kuehn}, K. and {Kuropatkin}, N. and {Lahav}, O. and {Lima}, M. and {Maia}, M.~A.~G. and {March}, M. and {Marshall}, J.~L. and {Melchior}, P. and {Menanteau}, F. and {Miquel}, R. and {Plazas}, A.~A. and {Sanchez}, E. and {Scarpine}, V. and {Sevilla-Noarbe}, I. and {Smith}, M. and {Soares-Santos}, M. and {Sobreira}, F. and {Suchyta}, E. and {Swanson}, M.~E.~C. and {Tarle}, G. and {Walker}, A.~R.},
+       author = {{Shajib}, Anowar J. and {Birrer}, Simon and {Treu}, T. and {Auger}, M.~W. and {Agnello}, A. and {Anguita}, T. and {Buckley-Geer}, E.~J. and {Chan}, J.~H.~H. and {Collett}, T.~E. and {Courbin}, F. and {Fassnacht}, C.~D. and {Frieman}, J. and {Kayo}, I. and {Lemon}, C. and {Lin}, H. and {Marshall}, P.~J. and {McMahon}, R. and {More}, A. and {Morgan}, N.~D. and {Motta}, V. and {Oguri}, M. and {Ostrovski}, F. and {Rusu}, C.~E. and {Schechter}, P.~L. and {Shanks}, T. and {Suyu}, S.~H. and {Meylan}, G. and {Abbott}, T.~M.~C. and {Allam}, S. and {Annis}, J. and {Avila}, S. and {Bertin}, E. and {Brooks}, D. and {Carnero Rosell}, A. and {Carrasco Kind}, M. and {Carretero}, J. and {Cunha}, C.~E. and {da Costa}, L.~N. and {De Vicente}, J. and {Desai}, S. and {Doel}, P. and {Flaugher}, B. and {Fosalba}, P. and {Garc{\'\i}a-Bellido}, J. and {Gerdes}, D.~W. and {Gruen}, D. and {Gruendl}, R.~A. and {Gutierrez}, G. and {Hartley}, W.~G. and {Hollowood}, D.~L. and {Hoyle}, B. and {James}, D.~J. and {Kuehn}, K. and {Kuropatkin}, N. and {Lahav}, O. and {Lima}, M. and {Maia}, M.~A.~G. and {March}, M. and {Marshall}, J.~L. and {Melchior}, P. and {Menanteau}, F. and {Miquel}, R. and {Plazas}, A.~A. and {Sanchez}, E. and {Scarpine}, V. and {Sevilla-Noarbe}, I. and {Smith}, M. and {Soares-Santos}, M. and {Sobreira}, F. and {Suchyta}, E. and {Swanson}, M.~E.~C. and {Tarle}, G. and {Walker}, A.~R.},
         title = "{Is every strong lens model unhappy in its own way? Uniform modelling of a sample of 13 quadruply+ imaged quasars}",
       journal = {Monthly Notices of the Royal Astronomical Society},
      keywords = {gravitational lensing: strong, methods: data analysis, galaxies: elliptical and lenticular, cD, galaxies: structure, Astrophysics - Astrophysics of Galaxies},
@@ -666,7 +666,7 @@ archivePrefix = {arXiv},
 
 
 @ARTICLE{Birrer:2019,
-       author = {{Birrer}, S. and {Treu}, T. and {Rusu}, C.~E. and {Bonvin}, V. and {Fassnacht}, C.~D. and {Chan}, J.~H.~H. and {Agnello}, A. and {Shajib}, A.~J. and {Chen}, G.~C. -F. and {Auger}, M. and {Courbin}, F. and {Hilbert}, S. and {Sluse}, D. and {Suyu}, S.~H. and {Wong}, K.~C. and {Marshall}, P. and {Lemaux}, B.~C. and {Meylan}, G.},
+       author = {{Birrer}, Simon and {Treu}, T. and {Rusu}, C.~E. and {Bonvin}, V. and {Fassnacht}, C.~D. and {Chan}, J.~H.~H. and {Agnello}, A. and {Shajib}, Anowar J. and {Chen}, G.~C. -F. and {Auger}, M. and {Courbin}, F. and {Hilbert}, S. and {Sluse}, D. and {Suyu}, S.~H. and {Wong}, K.~C. and {Marshall}, P. and {Lemaux}, B.~C. and {Meylan}, G.},
         title = "{H0LiCOW - IX. Cosmographic analysis of the doubly imaged quasar SDSS 1206+4332 and a new measurement of the Hubble constant}",
       journal = {Monthly Notices of the Royal Astronomical Society},
      keywords = {ravitational lensing: strong, cosmological parameters, dark energy, Astrophysics - Cosmology and Nongalactic Astrophysics},
@@ -914,7 +914,7 @@ archivePrefix = {arXiv},
 
 
 @ARTICLE{Birrer:2020tdcosmoiv,
-       author = {{Birrer}, S. and {Shajib}, A.~J. and {Galan}, A. and {Millon}, M. and {Treu}, T. and {Agnello}, A. and {Auger}, M. and {Chen}, G.~C. -F. and {Christensen}, L. and {Collett}, T. and {Courbin}, F. and {Fassnacht}, C.~D. and {Koopmans}, L.~V.~E. and {Marshall}, P.~J. and {Park}, J. -W. and {Rusu}, C.~E. and {Sluse}, D. and {Spiniello}, C. and {Suyu}, S.~H. and {Wagner-Carena}, S. and {Wong}, K.~C. and {Barnab{\`e}}, M. and {Bolton}, A.~S. and {Czoske}, O. and {Ding}, X. and {Frieman}, J.~A. and {Van de Vyvere}, L.},
+       author = {{Birrer}, Simon and {Shajib}, Anowar J. and {Galan}, A. and {Millon}, M. and {Treu}, T. and {Agnello}, A. and {Auger}, M. and {Chen}, G.~C. -F. and {Christensen}, L. and {Collett}, T. and {Courbin}, F. and {Fassnacht}, C.~D. and {Koopmans}, L.~V.~E. and {Marshall}, P.~J. and {Park}, J. -W. and {Rusu}, C.~E. and {Sluse}, D. and {Spiniello}, C. and {Suyu}, S.~H. and {Wagner-Carena}, S. and {Wong}, K.~C. and {Barnab{\`e}}, M. and {Bolton}, A.~S. and {Czoske}, O. and {Ding}, Xuheng and {Frieman}, J.~A. and {Van de Vyvere}, L.},
         title = "{TDCOSMO. IV. Hierarchical time-delay cosmography {\textendash} joint inference of the Hubble constant and galaxy density profiles}",
       journal = {Astronomy & Astrophysics},
      keywords = {gravitational lensing: strong, galaxies: general, galaxies: kinematics and dynamics, distance scale, cosmological parameters, cosmology: observations, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
@@ -935,7 +935,7 @@ archivePrefix = {arXiv},
 
 
 @ARTICLE{Shajib:2020strides,
-       author = {{Shajib}, A.~J. and {Birrer}, S. and {Treu}, T. and {Agnello}, A. and {Buckley-Geer}, E.~J. and {Chan}, J.~H.~H. and {Christensen}, L. and {Lemon}, C. and {Lin}, H. and {Millon}, M. and {Poh}, J. and {Rusu}, C.~E. and {Sluse}, D. and {Spiniello}, C. and {Chen}, G.~C. -F. and {Collett}, T. and {Courbin}, F. and {Fassnacht}, C.~D. and {Frieman}, J. and {Galan}, A. and {Gilman}, D. and {More}, A. and {Anguita}, T. and {Auger}, M.~W. and {Bonvin}, V. and {McMahon}, R. and {Meylan}, G. and {Wong}, K.~C. and {Abbott}, T.~M.~C. and {Annis}, J. and {Avila}, S. and {Bechtol}, K. and {Brooks}, D. and {Brout}, D. and {Burke}, D.~L. and {Carnero Rosell}, A. and {Carrasco Kind}, M. and {Carretero}, J. and {Castander}, F.~J. and {Costanzi}, M. and {da Costa}, L.~N. and {De Vicente}, J. and {Desai}, S. and {Dietrich}, J.~P. and {Doel}, P. and {Drlica-Wagner}, A. and {Evrard}, A.~E. and {Finley}, D.~A. and {Flaugher}, B. and {Fosalba}, P. and {Garc{\'\i}a-Bellido}, J. and {Gerdes}, D.~W. and {Gruen}, D. and {Gruendl}, R.~A. and {Gschwend}, J. and {Gutierrez}, G. and {Hollowood}, D.~L. and {Honscheid}, K. and {Huterer}, D. and {James}, D.~J. and {Jeltema}, T. and {Krause}, E. and {Kuropatkin}, N. and {Li}, T.~S. and {Lima}, M. and {MacCrann}, N. and {Maia}, M.~A.~G. and {Marshall}, J.~L. and {Melchior}, P. and {Miquel}, R. and {Ogando}, R.~L.~C. and {Palmese}, A. and {Paz-Chinch{\'o}n}, F. and {Plazas}, A.~A. and {Romer}, A.~K. and {Roodman}, A. and {Sako}, M. and {Sanchez}, E. and {Santiago}, B. and {Scarpine}, V. and {Schubnell}, M. and {Scolnic}, D. and {Serrano}, S. and {Sevilla-Noarbe}, I. and {Smith}, M. and {Soares-Santos}, M. and {Suchyta}, E. and {Tarle}, G. and {Thomas}, D. and {Walker}, A.~R. and {Zhang}, Y.},
+       author = {{Shajib}, Anowar J. and {Birrer}, Simon and {Treu}, T. and {Agnello}, A. and {Buckley-Geer}, E.~J. and {Chan}, J.~H.~H. and {Christensen}, L. and {Lemon}, C. and {Lin}, H. and {Millon}, M. and {Poh}, J. and {Rusu}, C.~E. and {Sluse}, D. and {Spiniello}, C. and {Chen}, G.~C. -F. and {Collett}, T. and {Courbin}, F. and {Fassnacht}, C.~D. and {Frieman}, J. and {Galan}, A. and {Gilman}, D. and {More}, A. and {Anguita}, T. and {Auger}, M.~W. and {Bonvin}, V. and {McMahon}, R. and {Meylan}, G. and {Wong}, K.~C. and {Abbott}, T.~M.~C. and {Annis}, J. and {Avila}, S. and {Bechtol}, K. and {Brooks}, D. and {Brout}, D. and {Burke}, D.~L. and {Carnero Rosell}, A. and {Carrasco Kind}, M. and {Carretero}, J. and {Castander}, F.~J. and {Costanzi}, M. and {da Costa}, L.~N. and {De Vicente}, J. and {Desai}, S. and {Dietrich}, J.~P. and {Doel}, P. and {Drlica-Wagner}, A. and {Evrard}, A.~E. and {Finley}, D.~A. and {Flaugher}, B. and {Fosalba}, P. and {Garc{\'\i}a-Bellido}, J. and {Gerdes}, D.~W. and {Gruen}, D. and {Gruendl}, R.~A. and {Gschwend}, J. and {Gutierrez}, G. and {Hollowood}, D.~L. and {Honscheid}, K. and {Huterer}, D. and {James}, D.~J. and {Jeltema}, T. and {Krause}, E. and {Kuropatkin}, N. and {Li}, T.~S. and {Lima}, M. and {MacCrann}, N. and {Maia}, M.~A.~G. and {Marshall}, J.~L. and {Melchior}, P. and {Miquel}, R. and {Ogando}, R.~L.~C. and {Palmese}, A. and {Paz-Chinch{\'o}n}, F. and {Plazas}, A.~A. and {Romer}, A.~K. and {Roodman}, A. and {Sako}, M. and {Sanchez}, E. and {Santiago}, B. and {Scarpine}, V. and {Schubnell}, M. and {Scolnic}, D. and {Serrano}, S. and {Sevilla-Noarbe}, I. and {Smith}, M. and {Soares-Santos}, M. and {Suchyta}, E. and {Tarle}, G. and {Thomas}, D. and {Walker}, A.~R. and {Zhang}, Y.},
         title = "{STRIDES: a 3.9 per cent measurement of the Hubble constant from the strong lens system DES J0408-5354}",
       journal = {Monthly Notices of the Royal Astronomical Society},
      keywords = {gravitational lensing: strong, cosmological parameters, distance scale, cosmology: observations, Astrophysics - Cosmology and Nongalactic Astrophysics},


### PR DESCRIPTION
This standardises all names which end up showing up in the draft.