### PR TITLE
Added NIE and CHAMELEON to list of viable 3d light models

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ Contributors (alphabetic)
 * Adam Amara `aamara <https://github.com/aamara/>`_
 * Xuheng Ding `dartoon <https://github.com/dartoon/>`_
 * Kevin Fusshoeller
+* Matthew R. Gomer `mattgomer <https://github.com/mattgomer>`_
 * Felix A. Kuhn
 * Felix Mayor
 * Martin Millon `martin-millon <https://github.com/martin-millon/>`_

--- a/lenstronomy/LightModel/light_model_base.py
+++ b/lenstronomy/LightModel/light_model_base.py
@@ -136,9 +136,10 @@ class LightModelBase(object):
         for i, func in enumerate(self.func_list):
             if bool_list[i] is True:
                 kwargs = {k: v for k, v in kwargs_list_standard[i].items() if not k in ['center_x', 'center_y']}
-                if self.profile_type_list[i] in ['HERNQUIST', 'HERNQUIST_ELLIPSE', 'PJAFFE', 'PJAFFE_ELLIPSE',
+                if self.profile_type_list[i] in ['DOUBLE_CHAMELEON', 'CHAMELEON', 'HERNQUIST', 
+						     'HERNQUIST_ELLIPSE', 'PJAFFE', 'PJAFFE_ELLIPSE',
                                                      'GAUSSIAN', 'GAUSSIAN_ELLIPSE', 'MULTI_GAUSSIAN',
-                                                     'MULTI_GAUSSIAN_ELLIPSE', 'POWER_LAW']:
+                                                     'MULTI_GAUSSIAN_ELLIPSE', 'NIE', 'POWER_LAW', 'TRIPLE_CHAMELEON']:
                     flux += func.light_3d(r, **kwargs)
                 else:
                     raise ValueError('Light model %s does not support a 3d light distribution!'


### PR DESCRIPTION
Added 'NIE', 'CHAMELEON', 'DOUBLE_CHAMELEON', and 'TRIPLE_CHAMELEON' to LightModel.light_model_base.py list of models which have viable 3d light distributions. Galkin should now work with these models without using MGE.