### PR TITLE
Remove the limit on s for the Fastell SPEMD

### DIFF
--- a/lenstronomy/LensModel/Profiles/spemd.py
+++ b/lenstronomy/LensModel/Profiles/spemd.py
@@ -223,7 +223,7 @@ class SPEMD(LensProfileBase):
         :param s2: square of smoothing scale of the core
         :return: bool of whether or not to let the fastell provide to be evaluated or instead return zero(s)
         """
-        if q_fastell < 0 or s2 < 0.0000000000001 or q > 1 or q < 0.01 or gam > 0.999 or gam < 0.001 or \
+        if q_fastell < 0 or q > 1 or q < 0.01 or gam > 0.999 or gam < 0.001 or \
                 not np.isfinite(q_fastell):
             return False
         return True


### PR DESCRIPTION
This removes the limit on s_scale^2>1e-13 for the SPEMD profile. This way, the EPL and SPEMD profiles can be compared a bit better numerically (EPL has s_scale=0). Or is there a good reason to keep this limit?
As a side note, the PEMD profile has a fixed s_scale=1e-5.