### PR TITLE
Number of images check and allow for covariance matrix

### DIFF
--- a/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
@@ -17,7 +17,10 @@ class FluxRatioLikelihood(object):
         :param lens_model_class: LensModel class instance
         :param param_class: Param() class instance
         :param flux_ratios: ratio of fluxes of the multiple images (relative to the first appearing)
-        :param flux_ratio_errors: errors in the flux ratios (relative to the first appearing
+        :param flux_ratio_errors: errors in the flux ratios (relative to the first appearing. Alternatively 
+        a log-normal covariance matrix. Note: in the case of a the covariance matrix, the errors are are assumed
+        to be log-normal, i.e. the logarithms of the flux ratios, ln(F[i]/F[0]) are assumed to have a multivariate 
+        Gaussian distribution, with the given covariance matrix.
         :param source_type: string, type of source, 'INF' specifies a point source, while 'GAUSSIAN' specifies a
         finite-size source modeled as a Gaussian
         :param window_size: size of window to compute the finite flux

--- a/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
@@ -12,7 +12,8 @@ class TimeDelayLikelihood(object):
         """
 
         :param time_delays_measured: relative time delays (in days) in respect to the first image of the point source
-        :param time_delays_uncertainties: time-delay uncertainties in same order as time_delay_measured
+        :param time_delays_uncertainties: time-delay uncertainties in same order as time_delay_measured. Alternatively
+        a full covariance matrix that describes the likelihood.
         :param lens_model_class: instance of the LensModel() class
         :param point_source_class: instance of the PointSource() class, note: the first point source type is the one the
         time delays are imposed on

--- a/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/time_delay_likelihood.py
@@ -52,8 +52,14 @@ class TimeDelayLikelihood(object):
         :param delays_errors: gaussian errors on the measured delays
         :return: log likelihood of data given model
         """
+        if len(delays_model)-1 != len(delays_measured):
+            return -10**(15)
         delta_t_model = np.array(delays_model[1:]) - delays_model[0]
-        logL = np.sum(-(delta_t_model - delays_measured) ** 2 / (2 * delays_errors ** 2))
+        if delays_errors.ndim <= 1:
+            logL = np.sum(-(delta_t_model - delays_measured) ** 2 / (2 * delays_errors ** 2))
+        elif delays_errors.ndim == 2:
+            D = delta_t_model - delays_measured
+            logL = -1/2* D @ np.linalg.inv(delays_errors) @ D # TODO: only calculate the inverse once
         return logL
 
     @property

--- a/test/test_Sampling/test_Likelihoods/test_flux_ratio_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_flux_ratio_likelihood.py
@@ -34,11 +34,16 @@ class TestFluxRatioLikelihood(object):
                                                               grid_number=grid_number)
         flux_ratios = mag_finite[1:] / mag_finite[0]
         flux_ratio_errors = [0.1, 0.1, 0.1]
+        flux_ratio_cov = np.diag([0.1, 0.1, 0.1])**2
         self.flux_likelihood = FluxRatioLikelihood(lens_model_class=lensModel, flux_ratios=flux_ratios, flux_ratio_errors=flux_ratio_errors,
                  source_type='GAUSSIAN', window_size=window_size, grid_number=grid_number)
 
         self.flux_likelihood_inf = FluxRatioLikelihood(lens_model_class=lensModel, flux_ratios=flux_ratios,
                                                    flux_ratio_errors=flux_ratio_errors,
+                                                   source_type='INF', window_size=window_size,
+                                                   grid_number=grid_number)
+        self.flux_likelihood_inf_cov = FluxRatioLikelihood(lens_model_class=lensModel, flux_ratios=flux_ratios,
+                                                   flux_ratio_errors=flux_ratio_cov,
                                                    source_type='INF', window_size=window_size,
                                                    grid_number=grid_number)
         self.kwargs_cosmo = {'source_size': source_size_arcsec}
@@ -68,6 +73,16 @@ class TestFluxRatioLikelihood(object):
         flux_ratios = np.array([1., 1., 1.])
         logL = flux_likelihood._logL(flux_ratios)
         assert logL == -10 ** 15
+
+    def test_numimgs(self):
+        # Test with a different number of images
+        logL = self.flux_likelihood.logL(self.x_img[:-1], self.y_img[:-1], self.kwargs_lens, kwargs_cosmo=self.kwargs_cosmo)
+        assert logL == -10**15
+
+    def test_covmatrix(self):
+        # Test with a different number of images
+        logL = self.flux_likelihood_inf_cov.logL(self.x_img, self.y_img, self.kwargs_lens, kwargs_cosmo=self.kwargs_cosmo)
+        npt.assert_almost_equal(logL,0,decimal=8)
 
 
 if __name__ == '__main__':

--- a/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
@@ -65,6 +65,25 @@ class TestImageLikelihood(object):
         logL = td_likelihood.logL(kwargs_lens=kwargs_lens, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
         npt.assert_almost_equal(logL, -0.5, decimal=8)
 
+    
+        # Test a covariance matrix being used
+        time_delays_cov = np.diag([0.1, 0.1, 0.1])**2
+        td_likelihood = TimeDelayLikelihood(time_delays_measured_new, time_delays_cov,
+                                                 lens_model_class=lensModel, point_source_class=pointSource)
+        logL = td_likelihood.logL(kwargs_lens=kwargs_lens, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
+        npt.assert_almost_equal(logL, -0.5, decimal=8)
+
+        # Test behaviour with a wrong number of images
+        time_delays_measured_new = time_delays_measured_new[:-1]
+        time_delays_uncertainties = time_delays_uncertainties[:-1] # remove last image
+        td_likelihood = TimeDelayLikelihood(time_delays_measured_new, time_delays_uncertainties,
+                                                 lens_model_class=lensModel, point_source_class=pointSource)
+        logL = td_likelihood.logL(kwargs_lens=kwargs_lens, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
+        npt.assert_almost_equal(logL, -10**15, decimal=8)
+        
+
+
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -49,7 +49,7 @@ class TestLikelihoodModule(object):
 
         self.kwargs_lens_light = [kwargs_sersic]
         self.kwargs_source = [kwargs_sersic_ellipse]
-        self.kwargs_ps = [{'ra_source': 0.55, 'dec_source': 0.02,
+        self.kwargs_ps = [{'ra_source': 0.05, 'dec_source': 0.02,
                            'source_amp': 1.}]  # quasar point source position in the source plane and intrinsic brightness
         self.kwargs_cosmo = {'D_dt': 1000}
         kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False}
@@ -96,10 +96,10 @@ class TestLikelihoodModule(object):
                              'image_position_likelihood': True
                              }
         self.kwargs_data = {'multi_band_list': [[kwargs_band, kwargs_psf, kwargs_numerics]], 'multi_band_type': 'single-band',
-                            'time_delays_measured': np.ones(4),
-                            'time_delays_uncertainties': np.ones(4),
-                            'flux_ratios': np.ones(4),
-                            'flux_ratio_errors': np.ones(4),
+                            'time_delays_measured': np.ones(3),
+                            'time_delays_uncertainties': np.ones(3),
+                            'flux_ratios': np.ones(3),
+                            'flux_ratio_errors': np.ones(3),
                             'ra_image_list': ra_pos,
                             'dec_image_list': dec_pos
                             }
@@ -128,7 +128,7 @@ class TestLikelihoodModule(object):
                                             kwargs_lens_light=self.kwargs_lens_light, kwargs_ps=self.kwargs_ps, kwargs_special=self.kwargs_cosmo)
 
         logL = likelihood.logL(args, verbose=True)
-        npt.assert_almost_equal(logL, -3097.189103539873, decimal=-1)
+        npt.assert_almost_equal(logL, -1328.821179288249, decimal=-1)
 
     def test_check_bounds(self):
         penalty, bound_hit = self.Likelihood.check_bounds(args=[0, 1], lowerLimit=[1, 0], upperLimit=[2, 2],


### PR DESCRIPTION
Checks if the num. of images is the same for the model and the data of
flux ratios, and if not returns a very low likelihood.
And allows one to pass a covariance matrix instead of Gaussian errors.

I'll add some more documentation and some tests too...