### PR TITLE
add mag_pert to source_position PointSource

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Contributors (alphabetic)
 * Joel Akeret `jakeret <https://github.com/jakeret/>`_
 * Adam Amara `aamara <https://github.com/aamara/>`_
 * Xuheng Ding `dartoon <https://github.com/dartoon/>`_
+* Sydney Erickson `smericks <https://github.com/smericks/>`_
 * Kevin Fusshoeller
 * Matthew R. Gomer `mattgomer <https://github.com/mattgomer>`_
 * Felix A. Kuhn

--- a/lenstronomy/PointSource/Types/base_ps.py
+++ b/lenstronomy/PointSource/Types/base_ps.py
@@ -98,7 +98,9 @@ def _expand_to_array(array, num):
 
 def _shrink_array(array, num):
     """
-    
+    :param array: float/int or numpy array
+    :param num: number of array entries expected in array
+    :return: array of size num, or scalar if array is a scalar
     """
     if np.isscalar(array):
         return array

--- a/lenstronomy/PointSource/Types/source_position.py
+++ b/lenstronomy/PointSource/Types/source_position.py
@@ -10,8 +10,9 @@ class SourcePositions(PSBase):
     The lens equation is solved to compute the image positions for the specified source position.
 
     Name within the PointSource module: 'SOURCE_POSITION'
-    parameters: ra_source, dec_source, source_amp
+    parameters: ra_source, dec_source, source_amp, mag_pert (optional)
     If fixed_magnification=True, than 'source_amp' is a parameter instead of 'point_amp'
+    mag_pert is a list of fractional magnification pertubations applied to point source images
 
     """
 
@@ -79,7 +80,7 @@ class SourcePositions(PSBase):
                 point_amp = _expand_to_array(point_amp, len(x_pos))
         mag_pert = kwargs_ps.get('mag_pert', 1)
         mag_pert = _shrink_array(mag_pert, len(point_amp))
-        point_amp *= mag_pert
+        point_amp *= np.array(mag_pert)
         return np.array(point_amp)
 
     def source_amplitude(self, kwargs_ps, kwargs_lens=None):

--- a/test/test_PointSource/test_Types/test_ps_base.py
+++ b/test/test_PointSource/test_Types/test_ps_base.py
@@ -45,13 +45,24 @@ class TestUtil(object):
         assert len(array_out) == num
         assert array_out[1] == 1
 
-    def test_shrink_arra(self):
+    def test_shrink_array(self):
 
         from lenstronomy.PointSource.Types.base_ps import _shrink_array
         array = [1, 2, 3]
         num = 2
         array_out = _shrink_array(array, num)
         assert len(array_out) == num
+        assert array_out[1] == 2
+
+        array = 1
+        num = 3
+        array_out = _shrink_array(array, num)
+        assert array_out == array
+
+        array = [1]
+        num = 2
+        with pytest.raises(ValueError):
+            _shrink_array(array, num)
 
 
 

--- a/test/test_PointSource/test_Types/test_source_position.py
+++ b/test/test_PointSource/test_Types/test_source_position.py
@@ -40,6 +40,13 @@ class TestLensedPosition(object):
                                               kwargs_lens_eqn_solver=None)
         npt.assert_almost_equal(amp, self.kwargs['point_amp'])
 
+        #see if works with mag_pert defined
+        self.kwargs['mag_pert'] = [0.1,0.1]
+        amp_pert = self.ps.image_amplitude(self.kwargs, kwargs_lens=self.kwargs_lens, x_pos=x_img,
+                                              y_pos=y_img, magnification_limit=None,
+                                              kwargs_lens_eqn_solver=None)
+        npt.assert_almost_equal(amp_pert, 0.1*amp)
+
     def test_source_amplitude(self):
         amp = self.ps.source_amplitude(self.kwargs, kwargs_lens=self.kwargs_lens)
         amp_mag = self.ps_mag.source_amplitude(self.kwargs_mag, kwargs_lens=self.kwargs_lens)


### PR DESCRIPTION
Added ability to apply magnification perturbations to images from a PointSource of type SOURCE_POSITION. This requires passing in a point source kwarg called 'mag_pert'. This change will allow users to make images from point sources with magnification errors. 