### PR TITLE
edit to adaptive magnification routine

### DIFF
--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -106,24 +106,27 @@ class LensModelExtensions(object):
 
         for xi, yi in zip(x_image, y_image):
 
-            w1, w2, v11, v12, v21, v22 = self.hessian_eigenvectors(xi, yi, kwargs_lens)
-            _v = [np.array([v11, v12]), np.array([v21, v22])]
-            _w = [abs(w1), abs(w2)]
-            if use_largest_eigenvalue:
-                idx = int(np.argmax(_w))
+            if axis_ratio == 1:
+                grid_r = np.hypot(grid_x_0, grid_y_0)
             else:
-                idx = int(np.argmin(_w))
-            v = _v[idx]
+                w1, w2, v11, v12, v21, v22 = self.hessian_eigenvectors(xi, yi, kwargs_lens)
+                _v = [np.array([v11, v12]), np.array([v21, v22])]
+                _w = [abs(w1), abs(w2)]
+                if use_largest_eigenvalue:
+                    idx = int(np.argmax(_w))
+                else:
+                    idx = int(np.argmin(_w))
+                v = _v[idx]
 
-            rotation_angle = np.arctan(v[1] / v[0]) - np.pi / 2
-            grid_x, grid_y = util.rotate(grid_x_0, grid_y_0, rotation_angle)
+                rotation_angle = np.arctan(v[1] / v[0]) - np.pi / 2
+                grid_x, grid_y = util.rotate(grid_x_0, grid_y_0, rotation_angle)
 
-            if axis_ratio == 0:
-                sort = np.argsort(_w)
-                q = _w[sort[0]] / _w[sort[1]]
-                grid_r = np.hypot(grid_x, grid_y / q).ravel()
-            else:
-                grid_r = np.hypot(grid_x, grid_y / axis_ratio).ravel()
+                if axis_ratio == 0:
+                    sort = np.argsort(_w)
+                    q = _w[sort[0]] / _w[sort[1]]
+                    grid_r = np.hypot(grid_x, grid_y / q).ravel()
+                else:
+                    grid_r = np.hypot(grid_x, grid_y / axis_ratio).ravel()
 
             flux_array = np.zeros_like(grid_x_0)
             step = step_size * grid_radius_arcsec

--- a/test/test_LensModel/test_lens_model_extensions.py
+++ b/test/test_LensModel/test_lens_model_extensions.py
@@ -122,8 +122,12 @@ class TestLensModelExtensions(object):
         mag_adaptive_grid_2 = extension.magnification_finite_adaptive(x_image, y_image, source_x, source_y, kwargs_lens,
                                                                       source_fwhm_parsec, z_source,
                                                                       cosmo=self.cosmo, axis_ratio=0)
+        mag_adaptive_grid_3 = extension.magnification_finite_adaptive(x_image, y_image, source_x, source_y, kwargs_lens,
+                                                                      source_fwhm_parsec, z_source,
+                                                                      cosmo=self.cosmo, axis_ratio=0)
 
         flux_ratios_adaptive_grid_2 = mag_adaptive_grid_2 / max(mag_adaptive_grid_2)
+        flux_ratios_adaptive_grid_3 = mag_adaptive_grid_3 / max(mag_adaptive_grid_3)
 
         # tests the default cosmology
         _ = extension.magnification_finite_adaptive(x_image, y_image, source_x, source_y, kwargs_lens,
@@ -148,6 +152,8 @@ class TestLensModelExtensions(object):
         npt.assert_array_less(flux_ratios_fixed_aperture_size / flux_ratios_adaptive_grid - 1,
                               quarter_precent_precision)
         npt.assert_array_less(flux_ratios_square_grid / flux_ratios_adaptive_grid_2 - 1,
+                              quarter_precent_precision)
+        npt.assert_array_less(flux_ratios_adaptive_grid_3 / flux_ratios_adaptive_grid_2 - 1,
                               quarter_precent_precision)
         half_percent_precision = [0.005] * 4
         npt.assert_array_less(mag_square_grid / mag_adaptive_grid - 1, half_percent_precision)

--- a/test/test_LensModel/test_lens_model_extensions.py
+++ b/test/test_LensModel/test_lens_model_extensions.py
@@ -124,7 +124,7 @@ class TestLensModelExtensions(object):
                                                                       cosmo=self.cosmo, axis_ratio=0)
         mag_adaptive_grid_3 = extension.magnification_finite_adaptive(x_image, y_image, source_x, source_y, kwargs_lens,
                                                                       source_fwhm_parsec, z_source,
-                                                                      cosmo=self.cosmo, axis_ratio=0)
+                                                                      cosmo=self.cosmo, axis_ratio=1)
 
         flux_ratios_adaptive_grid_2 = mag_adaptive_grid_2 / max(mag_adaptive_grid_2)
         flux_ratios_adaptive_grid_3 = mag_adaptive_grid_3 / max(mag_adaptive_grid_3)


### PR DESCRIPTION
If the grid axis ratio = 1, no need to compute the eigenvalues of the hessian matrix for the rotation of the ray-tracing ellipse, since it's a circle and not an ellipse. I think this was causing a crash with lots of point-mass lens models, where some eigenvalues were nan  