### PR TITLE
PSF error map

### DIFF
--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -56,8 +56,8 @@ class PSF(object):
             self._kernel_point_source[1, 1] = 1
         else:
             raise ValueError("psf_type %s not supported!" % self.psf_type)
-        n_kernel = len(self._kernel_point_source)
         if psf_error_map is not None:
+            n_kernel = len(self.kernel_point_source)
             self._psf_error_map = kernel_util.match_kernel_size(psf_error_map, n_kernel)
             self._psf_error_map = psf_error_map
             if self.psf_type == 'PIXEL' and point_source_supersampling_factor > 1:
@@ -72,7 +72,7 @@ class PSF(object):
     def kernel_point_source(self):
         if not hasattr(self, '_kernel_point_source'):
             if self.psf_type == 'GAUSSIAN':
-                kernel_num_pix = round(self._truncation * self._fwhm / self._pixel_size)
+                kernel_num_pix = min(round(self._truncation * self._fwhm / self._pixel_size), 201)
                 if kernel_num_pix % 2 == 0:
                     kernel_num_pix += 1
                 self._kernel_point_source = kernel_util.kernel_gaussian(kernel_num_pix, self._pixel_size, self._fwhm)

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -23,7 +23,7 @@ class PSF(object):
         :param pixel_size: width of pixel (required for Gaussian model, not required when using in combination with ImageModel modules)
         :param kernel_point_source: 2d numpy array, odd length, centered PSF of a point source
          (if not normalized, will be normalized)
-        :param psf_error_map: uncertainty in the PSF model per pixel (size of data, not supersampled). 2d numpy array.
+        :param psf_error_map: uncertainty in the PSF model per pixel (size of data, not super-sampled). 2d numpy array.
         Size can be larger or smaller than the pixel-sized PSF model and if so, will be matched.
         This error will be added to the pixel error around the position of point sources as follows:
         sigma^2_i += 'psf_error_map'_j * (point_source_flux_i)**2
@@ -72,10 +72,10 @@ class PSF(object):
     def kernel_point_source(self):
         if not hasattr(self, '_kernel_point_source'):
             if self.psf_type == 'GAUSSIAN':
-                kernel_numPix = round(self._truncation * self._fwhm / self._pixel_size)
-                if kernel_numPix % 2 == 0:
-                    kernel_numPix += 1
-                self._kernel_point_source = kernel_util.kernel_gaussian(kernel_numPix, self._pixel_size, self._fwhm)
+                kernel_num_pix = round(self._truncation * self._fwhm / self._pixel_size)
+                if kernel_num_pix % 2 == 0:
+                    kernel_num_pix += 1
+                self._kernel_point_source = kernel_util.kernel_gaussian(kernel_num_pix, self._pixel_size, self._fwhm)
         return self._kernel_point_source
 
     @property

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -59,7 +59,6 @@ class PSF(object):
         if psf_error_map is not None:
             n_kernel = len(self.kernel_point_source)
             self._psf_error_map = kernel_util.match_kernel_size(psf_error_map, n_kernel)
-            self._psf_error_map = psf_error_map
             if self.psf_type == 'PIXEL' and point_source_supersampling_factor > 1:
                 if len(psf_error_map) == len(self._kernel_point_source_supersampled):
                     Warning('psf_error_map has the same size as the super-sampled kernel. Make sure the units in the'

--- a/lenstronomy/Util/kernel_util.py
+++ b/lenstronomy/Util/kernel_util.py
@@ -435,7 +435,7 @@ def estimate_amp(data, x_pos, y_pos, psf_kernel):
     #data_center = int((numPix-1.)/2)
     x_int = int(round(x_pos-0.49999))#+data_center
     y_int = int(round(y_pos-0.49999))#+data_center
-    # TODO: make amplitude estimate not sucecible to rounding effects on which pixels to chose to estimate the amplitude
+    # TODO: make amplitude estimate not sucebtible to rounding effects on which pixels to chose to estimate the amplitude
     if x_int > 2 and x_int < numPix_x-2 and y_int > 2 and y_int < numPix_y-2:
         mean_image = max(np.sum(data[y_int - 2:y_int+3, x_int-2:x_int+3]), 0)
         num = len(psf_kernel)
@@ -465,3 +465,24 @@ def mge_kernel(kernel, order=5):
     amps, sigmas, norm = mge.mge_1d(r_array, psf_r, N=order, linspace=True)
     return amps, sigmas, norm
 
+
+@export
+def match_kernel_size(image, size):
+    """
+    matching kernel/image to a dedicated size by either expanding the image with zeros at the edges or chopping of the
+    edges.
+
+    :param image: 2d array (square with odd number of pixels)
+    :param size: integer (odd number)
+    :return: image with matched size, either by cutting or by adding zeros in the outskirts
+    """
+    n = len(image)
+    if n == size:
+        return image
+    image_copy = copy.deepcopy(image)
+    if n > size:
+        return image_copy[int((n-size)/2): int(n - (n-size)/2), int((n-size)/2): int(n - (n-size)/2)]
+    else:
+        image_add = np.zeros((size, size))
+        image_add[int((size - n)/2): int(size - (size - n)/2), int((size - n)/2): int(size - (size - n)/2)] = image_copy
+        return image_add

--- a/test/test_Data/test_psf.py
+++ b/test/test_Data/test_psf.py
@@ -124,6 +124,26 @@ class TestData(object):
         error_map = psf_kernel.psf_error_map
         assert error_map.all() == 0
 
+    def test_warning(self):
+        deltaPix = 0.05  # pixel size of image
+        subsampling_res = 4  # subsampling scale factor (in each dimension)
+        fwhm = 0.3  # FWHM of the PSF kernel
+
+        # create Gaussian/Pixelized kernels
+        # first we create the sub-sampled kernel
+        kernel_point_source_subsampled = kernel_util.kernel_gaussian(kernel_numPix=11 * subsampling_res + 1,
+                                                                     deltaPix=deltaPix / subsampling_res, fwhm=fwhm)
+        print(len(kernel_point_source_subsampled), 'test')
+        kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': kernel_point_source_subsampled,
+                      'point_source_supersampling_factor': subsampling_res,
+                      'psf_error_map': np.ones_like(kernel_point_source_subsampled)}
+        psf_kernel = PSF(**kwargs_psf)
+        n = len(psf_kernel.kernel_point_source)
+        error_map = psf_kernel.psf_error_map
+        assert len(error_map) == n
+
+
+
 
 class TestRaise(unittest.TestCase):
 

--- a/test/test_SimulationAPI/test_sim_api.py
+++ b/test/test_SimulationAPI/test_sim_api.py
@@ -12,14 +12,13 @@ class TestModelAPI(object):
         instrument_name = 'LSST'
         observation_name = 'LSST_g_band'
         kwargs_single_band = constructor.observation_constructor(instrument_name=instrument_name,
-                                                          observation_name=observation_name)
+                                                                 observation_name=observation_name)
         kwargs_single_band['data_count_unit'] = 'e-'
         kwargs_model = {'lens_model_list': ['SIS'], 'z_lens': None, 'z_source': None, 'lens_redshift_list': None,
                         'source_light_model_list': ['GAUSSIAN'],
                         'lens_light_model_list': ['SERSIC'], 'point_source_model_list':['UNLENSED'],
                         'source_redshift_list': None}
         kwargs_numerics = {'supersampling_factor': 2}
-
         self.api = SimAPI(numpix, kwargs_single_band, kwargs_model)
 
     def test_image_model_class(self):

--- a/test/test_Util/test_kernel_util.py
+++ b/test/test_Util/test_kernel_util.py
@@ -335,6 +335,30 @@ def test_degrade_kernel():
     npt.assert_almost_equal(np.sum(kernel_degraded), 1, decimal=8)
 
 
+def test_match_kernel_sixe():
+
+    image = np.ones((21, 21))
+    size = 11
+    image_match = kernel_util.match_kernel_size(image, size)
+    nx, ny = np.shape(image_match)
+    assert nx == size
+    assert ny == size
+
+    image = np.ones((9, 9))
+    size = 11
+    image_match = kernel_util.match_kernel_size(image, size)
+    nx, ny = np.shape(image_match)
+    assert nx == size
+    assert ny == size
+
+    image = np.ones((11, 11))
+    size = 11
+    image_match = kernel_util.match_kernel_size(image, size)
+    nx, ny = np.shape(image_match)
+    assert nx == size
+    assert ny == size
+
+
 class TestRaise(unittest.TestCase):
 
     def test_raise(self):


### PR DESCRIPTION
This PR enables more flexible pdf_error_map inputs that do not need to match the size of the PSF and will be made fit. Also improved documentation and a warning if there is a chance for misinterpretation. Future changes possible to accept supersampled error maps, but this needs to find changes in other parts of lenstronomy beyond the PSF class.
(partially) addresses issue #294 