### PR TITLE
Postpone imports

### DIFF
--- a/lenstronomy/GalKin/velocity_util.py
+++ b/lenstronomy/GalKin/velocity_util.py
@@ -1,6 +1,5 @@
 __author__ = 'sibirrer'
 
-import mpmath as mp
 import numpy as np
 
 from lenstronomy.Util.package_util import exporter
@@ -12,6 +11,8 @@ def hyp_2F1(a, b, c, z):
     """
     http://docs.sympy.org/0.7.1/modules/mpmath/functions/hypergeometric.html
     """
+    import mpmath as mp
+
     return mp.hyp2f1(a, b, c, z)
 
 

--- a/lenstronomy/LensModel/Profiles/gauss_decomposition.py
+++ b/lenstronomy/LensModel/Profiles/gauss_decomposition.py
@@ -9,7 +9,6 @@ __author__ = 'ajshajib'
 import numpy as np
 import abc
 from scipy.special import comb
-from future.utils import with_metaclass
 
 from lenstronomy.LensModel.Profiles.gaussian_ellipse_kappa import GaussianEllipseKappa
 from lenstronomy.LensModel.Profiles.sersic_utils import SersicUtil
@@ -198,7 +197,7 @@ class GaussianEllipseKappaSet(LensProfileBase):
 
 
 @export
-class GaussDecompositionAbstract(with_metaclass(abc.ABCMeta)):
+class GaussDecompositionAbstract(metaclass=abc.ABCMeta):
     """
     This abstract class sets up a template for computing lensing properties of
     an elliptical convergence through Shajib (2019)'s Gauss decomposition.

--- a/lenstronomy/LensModel/Profiles/uldm.py
+++ b/lenstronomy/LensModel/Profiles/uldm.py
@@ -4,7 +4,6 @@ __author__ = 'lucateo'
 import numpy as np
 import scipy.interpolate as interp
 from scipy.special import gamma, hyp2f1
-from mpmath import hyp3f2
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import lenstronomy.Util.constants as const
 __all__ = ['Uldm']
@@ -62,6 +61,8 @@ class Uldm(LensProfileBase):
         :param center_y: center of halo (in angular units)
         :return: lensing potential (in arcsec^2)
         """
+        from mpmath import hyp3f2
+
         x_ = x - center_x
         y_ = y - center_y
         r = np.sqrt(x_** 2 + y_** 2)

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -1,6 +1,5 @@
 import numpy as np
 import lenstronomy.Util.util as util
-from skimage.measure import find_contours
 from lenstronomy.Util.magnification_finite_util import setup_mag_finite
 
 __all__ = ['LensModelExtensions']
@@ -393,7 +392,10 @@ class LensModelExtensions(object):
         ra_caustic_list = []
         dec_caustic_list = []
 
+        # Import moved here to avoid import-time exception if skimage is missing
+        from skimage.measure import find_contours
         paths = find_contours(1/mag_high_res, 0.)
+
         for i, v in enumerate(paths):
             # x, y changed because of skimage conventions
             ra_points = v[:, 1] * grid_scale - grid_scale * (numPix-1)/2 + center_x

--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -1,6 +1,5 @@
 import numpy as np
 import math
-from corner import quantile
 import matplotlib.pyplot as plt
 
 from lenstronomy.Util.package_util import exporter
@@ -191,6 +190,8 @@ def result_string(x, weights=None, title_fmt=".2f", label=None):
     :param label: string of parameter label (optional)
     :return: string with mean \pm quartile
     """
+    from corner import quantile
+
     q_16, q_50, q_84 = quantile(x, [0.16, 0.5, 0.84], weights=weights)
     q_m, q_p = q_50 - q_16, q_84 - q_50
 

--- a/lenstronomy/Sampling/Pool/pool.py
+++ b/lenstronomy/Sampling/Pool/pool.py
@@ -33,9 +33,6 @@ log = logging.getLogger(__name__)
 _VERBOSE = 5
 
 #from schwimmbad.multiprocessing import MultiPool
-from lenstronomy.Sampling.Pool.multiprocessing import MultiPool
-from schwimmbad.serial import SerialPool
-from schwimmbad.mpi import MPIPool
 #from schwimmbad.jl import JoblibPool
 
 __all__ = ['choose_pool']
@@ -66,6 +63,11 @@ def choose_pool(mpi=False, processes=1, **kwargs):
     Any additional kwargs are passed in to the pool class initializer selected by the arguments.
 
     """
+    # Imports moved here to avoid crashing at import time if dependencies
+    # are missing
+    from lenstronomy.Sampling.Pool.multiprocessing import MultiPool
+    from schwimmbad.serial import SerialPool
+    from schwimmbad.mpi import MPIPool
 
     if mpi:
         if not MPIPool.enabled():

--- a/lenstronomy/Sampling/sampler.py
+++ b/lenstronomy/Sampling/sampler.py
@@ -6,7 +6,6 @@ import numpy as np
 from lenstronomy.Sampling.Samplers.pso import ParticleSwarmOptimizer
 from lenstronomy.Util import sampling_util
 from lenstronomy.Sampling.Pool.pool import choose_pool
-import emcee
 from scipy.optimize import minimize
 
 __all__ = ['Sampler']
@@ -152,6 +151,8 @@ class Sampler(object):
         :return: samples, ln likelihood value of samples
         :rtype: numpy 2d array, numpy 1d array
         """
+        import emcee
+
         num_param, _ = self.chain.param.num_param()
         if initpos is None:
             initpos = sampling_util.sample_ball_truncated(mean_start, sigma_start, self.lower_limit, self.upper_limit,

--- a/lenstronomy/Util/package_util.py
+++ b/lenstronomy/Util/package_util.py
@@ -53,6 +53,11 @@ def short(_laconic=False):
     all_modules = dict()
 
     for loader, module_name, is_pkg in pkgutil.walk_packages(lenstronomy.__path__):
+        # This deep internal module relies heavily on 'multiprocessing',
+        # which may not be installed
+        if module_name == 'Sampling.Pool.multiprocessing':
+            continue
+
         # Load the module
         module = all_modules[module_name] = \
             loader.find_module(module_name).load_module(module_name)

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -5,7 +5,6 @@ this file contains standard routines
 """
 
 import numpy as np
-import mpmath
 import itertools
 from lenstronomy.Util.numba_util import jit
 from lenstronomy.Util.package_util import exporter
@@ -566,6 +565,8 @@ def hyper2F2_array(a, b, c, d, x):
     :param x:
     :return:
     """
+    import mpmath
+
     if isinstance(x, int) or isinstance(x, float):
         out = mpmath.hyp2f2(a, b, c, d, x)
     else:


### PR DESCRIPTION
This moves imports of packages that are not lenstronomy dependencies inside the functions where they are used. Lenstronomy already does this, e.g. for [fastell4py here](https://github.com/sibirrer/lenstronomy/blob/cad2f7a3f580090fa2d4eb6d882727be3b137969/lenstronomy/LensModel/Profiles/spemd.py#L62) and for [astropy here](https://github.com/sibirrer/lenstronomy/blob/6db785667ff099fa8338e972b66253b2901b2827/test/test_LensModel/test_MultiPlane/test_multi_plane.py#L60). This PR merely does the same at 7 other points, of which 3 are for `mpmath`.

This will make lenstronomy easier to use. For example, if you use a function from [lens_model_extensions.py](https://github.com/sibirrer/lenstronomy/blob/main/lenstronomy/LensModel/lens_model_extensions.py), you currently get a `ModuleNotFoundError` unless `scikit-image` is installed, even though only one function in that file uses `scikit-image` (`critical_curve_caustics`).

Moreover, this makes the short and laconic APIs from #214 actually useful. Currently even I am wary of them as `ls.short()` and `ls.laconic()` require you to have many funky packages installed. After this, you can use these APIs in a clean environment with only lenstronomy and astropy. All packages that still have top-level imports in lenstronomy after this PR (like `numpy`, `pyyaml` and `matplotlib`) are dependencies of either lenstronomy or astropy; if you install both, any file in lenstronomy can at least be imported. (With one exception, see below.)

Two special cases:
  * `LensModel.Profiles.gauss_decomposition` used a base class from [future](https://pypi.org/project/future/) to paper over python 2/3 metaclass differences. Since lenstronomy dropped python 2 support last year, this is no longer needed. Other ways to avoid the top-level `future` import would probably be messy.
  * `Sampling.Pool.multiprocessing` is a deep internal module (vendored from Schwimmbad according to the comments) that has a seemingly unavoidable top-level import of [multiprocessing](https://pypi.org/project/multiprocessing/). Rather than changing anything here, I excluded this file from the short and laconic APIs, as users are unlikely to use it directly (as opposed to through `lenstronomy.Pool.pool.choose_pool`). People who are using it directly can just keep importing it explicitly.

Related issues: https://github.com/sibirrer/lenstronomy/issues/140, https://github.com/sibirrer/lenstronomy/issues/188