### PR TITLE
Astropy v5 compatibility

### DIFF
--- a/lenstronomy/Cosmo/_cosmo_interp_astropy_v4.py
+++ b/lenstronomy/Cosmo/_cosmo_interp_astropy_v4.py
@@ -2,7 +2,8 @@ import astropy
 if float(astropy.__version__[0]) < 5.0:
     from astropy.cosmology.core import vectorize_if_needed, isiterable
 else:
-    raise ValueError('This routines are only supported for astropy version <5. Current version is %s.' %astropy.__version__)
+    raise Warning('This routines are only supported for astropy version <5. Current version is %s.'
+                  % astropy.__version__)
 #
 from scipy.integrate import quad
 

--- a/lenstronomy/Cosmo/_cosmo_interp_astropy_v4.py
+++ b/lenstronomy/Cosmo/_cosmo_interp_astropy_v4.py
@@ -1,0 +1,44 @@
+import astropy
+if float(astropy.__version__[0]) < 5.0:
+    from astropy.cosmology.core import vectorize_if_needed, isiterable
+else:
+    raise ValueError('This routines are only supported for astropy version <5. Current version is %s.' %astropy.__version__)
+#
+from scipy.integrate import quad
+
+
+class CosmoInterp(object):
+    """
+    class which interpolates the comoving transfer distance and then computes angular diameter distances from it
+    This class is modifying the astropy.cosmology routines
+    """
+    def __init__(self, cosmo, z_stop, num_interp):
+        """
+
+        :param cosmo: astropy.cosmology instance (version 4.0 as private functions need to be supported)
+        :param z_stop: maximum redshift for the interpolation
+        :param num_interp: int, number of interpolating steps
+        """
+        self._cosmo = cosmo
+
+    def _integral_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at
+        redshifts z1 and z2.
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        Parameters
+        ----------
+        z1, z2 : array_like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+
+        f = lambda z1, z2: quad(self._cosmo._inv_efunc_scalar, z1, z2, args=self._cosmo._inv_efunc_scalar_args)[0]
+        return self._cosmo._hubble_distance * vectorize_if_needed(f, z1, z2)

--- a/lenstronomy/Cosmo/_cosmo_interp_astropy_v4.py
+++ b/lenstronomy/Cosmo/_cosmo_interp_astropy_v4.py
@@ -2,7 +2,7 @@ import astropy
 if float(astropy.__version__[0]) < 5.0:
     from astropy.cosmology.core import vectorize_if_needed, isiterable
 else:
-    raise Warning('This routines are only supported for astropy version <5. Current version is %s.'
+    Warning('This routines are only supported for astropy version <5. Current version is %s.'
                   % astropy.__version__)
 #
 from scipy.integrate import quad

--- a/lenstronomy/Cosmo/_cosmo_interp_astropy_v5.py
+++ b/lenstronomy/Cosmo/_cosmo_interp_astropy_v5.py
@@ -1,6 +1,7 @@
 import astropy
 if float(astropy.__version__[0]) < 5.0:
-    raise ValueError('This routines are only supported for astropy version >=5. Current version is %s.' %astropy.__version__)
+    Warning('This routines are only supported for astropy version >=5. Current version is %s.'
+            % astropy.__version__)
 else:
     from astropy.cosmology.utils import vectorize_redshift_method, isiterable
 

--- a/lenstronomy/Cosmo/_cosmo_interp_astropy_v5.py
+++ b/lenstronomy/Cosmo/_cosmo_interp_astropy_v5.py
@@ -1,0 +1,65 @@
+import astropy
+if float(astropy.__version__[0]) < 5.0:
+    raise ValueError('This routines are only supported for astropy version >=5. Current version is %s.' %astropy.__version__)
+else:
+    from astropy.cosmology.utils import vectorize_redshift_method, isiterable
+
+#
+from scipy.integrate import quad
+
+
+class CosmoInterp(object):
+    """
+    class which interpolates the comoving transfer distance and then computes angular diameter distances from it
+    This class is modifying the astropy.cosmology routines
+    """
+    def __init__(self, cosmo, z_stop, num_interp):
+        """
+
+        :param cosmo: astropy.cosmology instance (version 4.0 as private functions need to be supported)
+        :param z_stop: maximum redshift for the interpolation
+        :param num_interp: int, number of interpolating steps
+        """
+        self._cosmo = cosmo
+
+    def _integral_comoving_distance_z1z2(self, z1, z2):
+        """
+        Comoving line-of-sight distance in Mpc between objects at redshifts
+        ``z1`` and ``z2``. The comoving distance along the line-of-sight
+        between two objects remains constant with time for objects in the
+        Hubble flow.
+
+        Parameters
+        ----------
+        z1, z2 : Quantity-like ['redshift'] or array-like
+            Input redshifts.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity` ['length']
+            Comoving distance in Mpc between each input redshift.
+        """
+
+        return self._cosmo._hubble_distance * self._integral_comoving_distance_z1z2_scalar(z1, z2)
+
+    @vectorize_redshift_method(nin=2)
+    def _integral_comoving_distance_z1z2_scalar(self, z1, z2, /):
+        """
+        Comoving line-of-sight distance between objects at redshifts ``z1`` and
+        ``z2``. Value in Mpc.
+
+        The comoving distance along the line-of-sight between two objects
+        remains constant with time for objects in the Hubble flow.
+
+        Parameters
+        ----------
+        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+            Input redshifts.
+
+        Returns
+        -------
+        d : float or ndarray
+            Comoving distance in Mpc between each input redshift.
+            Returns `float` if input scalar, `~numpy.ndarray` otherwise.
+        """
+        return quad(self._cosmo._inv_efunc_scalar, z1, z2, args=self._cosmo._inv_efunc_scalar_args)[0]

--- a/lenstronomy/Cosmo/cosmo_interp.py
+++ b/lenstronomy/Cosmo/cosmo_interp.py
@@ -1,6 +1,9 @@
 import astropy
 if float(astropy.__version__[0]) < 5.0:
     from astropy.cosmology.core import isiterable
+    DeprecationWarning('Astropy<5 is going to be deprecated soon. This is in combination with Python version<3.8.'
+                       'We recommend you to update astropy to the latest versionbut keep supporting your settings for '
+                       'the time being.')
 else:
     from astropy.cosmology.utils import isiterable
 #

--- a/lenstronomy/Cosmo/cosmo_interp.py
+++ b/lenstronomy/Cosmo/cosmo_interp.py
@@ -1,5 +1,9 @@
-from astropy.cosmology.core import vectorize_if_needed, isiterable
-# from astropy.cosmology.utils import vectorize_redshift_method
+import astropy
+if float(astropy.__version__[0]) < 5.0:
+    from astropy.cosmology.core import isiterable
+else:
+    from astropy.cosmology.utils import isiterable
+#
 from astropy import units
 from math import sqrt
 import numpy as np
@@ -20,6 +24,12 @@ class CosmoInterp(object):
         :param num_interp: int, number of interpolating steps
         """
         self._cosmo = cosmo
+        if float(astropy.__version__[0]) < 5.0:
+            from lenstronomy.Cosmo._cosmo_interp_astropy_v4 import CosmoInterp as CosmoInterp_
+            self._comoving_interp = CosmoInterp_(cosmo, z_stop=z_stop, num_interp=num_interp)
+        else:
+            from lenstronomy.Cosmo._cosmo_interp_astropy_v5 import CosmoInterp as CosmoInterp_
+            self._comoving_interp = CosmoInterp_(cosmo, z_stop=z_stop, num_interp=num_interp)
         self._comoving_distance_interpolation_func = self._interpolate_comoving_distance(z_start=0, z_stop=z_stop,
                                                                                          num_interp=num_interp)
 
@@ -174,31 +184,7 @@ class CosmoInterp(object):
         running_dist = 0
         ang_dist = np.zeros(num_interp+1)
         for i in range(num_interp):
-            delta_dist = self._integral_comoving_distance_z1z2(z_steps[i], z_steps[i+1])
+            delta_dist = self._comoving_interp._integral_comoving_distance_z1z2(z_steps[i], z_steps[i+1])
             running_dist += delta_dist.value
             ang_dist[i+1] = copy.deepcopy(running_dist)
         return interp1d(z_steps, ang_dist)
-
-    def _integral_comoving_distance_z1z2(self, z1, z2):
-        """ Comoving line-of-sight distance in Mpc between objects at
-        redshifts z1 and z2.
-
-        The comoving distance along the line-of-sight between two
-        objects remains constant with time for objects in the Hubble
-        flow.
-
-        Parameters
-        ----------
-        z1, z2 : array_like, shape (N,)
-          Input redshifts.  Must be 1D or scalar.
-
-        Returns
-        -------
-        d : `~astropy.units.Quantity`
-          Comoving distance in Mpc between each input redshift.
-        """
-
-        from scipy.integrate import quad
-        f = lambda z1, z2: quad(self._cosmo._inv_efunc_scalar, z1, z2,
-                             args=self._cosmo._inv_efunc_scalar_args)[0]
-        return self._cosmo._hubble_distance * vectorize_if_needed(f, z1, z2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.17
-astropy<5
+astropy
 scipy>=0.19.1
 mpmath
 emcee>=3.0.0

--- a/test/test_Sampling/test_Samplers/test_multinest_sampler.py
+++ b/test/test_Sampling/test_Samplers/test_multinest_sampler.py
@@ -21,9 +21,9 @@ try:
 except:
     print("Warning : MultiNest/pymultinest not installed properly, \
 but tests will be trivially fulfilled")
-    pymultinest_installed =  False
+    pymultinest_installed = False
 else:
-    pymultinest_installed =  True
+    pymultinest_installed = True
 
 
 class TestMultiNestSampler(object):


### PR DESCRIPTION
makes lenstronomy fully compatible with astropy v5 and v4 by choosing different underlying function calls