### PR TITLE
change schwimmbad requirement to current pip version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ pyyaml
 pyxdg
 
 # schwimmbad version that is supporting dill, which is not the current pip release version
--e git://github.com/adrn/schwimmbad.git@master#egg=schwimmbad
+schwimmbad
+#-e git://github.com/adrn/schwimmbad.git@master#egg=schwimmbad
 multiprocess>=0.70.8
 # fastell is not a direct requirement as it needs a fortran compiler and is optional
 #-e git://github.com/sibirrer/fastell4py.git#egg=fastell4py


### PR DESCRIPTION
current installation of master branch causes errors in CI. Latest schwimmbad pip versions (based on main branch) may have the functionality use_dill available, which was the main reason not to use the latest pip version for lenstronomy. This PR is aimed to resolve this issue and hopefully make lenstronomy compatible with the latest pip version of schwimmbad