### PR TITLE
turn off linear inversion in likelihood

### DIFF
--- a/lenstronomy/ImSim/MultiBand/multi_linear.py
+++ b/lenstronomy/ImSim/MultiBand/multi_linear.py
@@ -23,19 +23,25 @@ class MultiLinear(MultiDataBase):
 
     """
 
-    def __init__(self, multi_band_list, kwargs_model, likelihood_mask_list=None, compute_bool=None, kwargs_pixelbased=None):
+    def __init__(self, multi_band_list, kwargs_model, likelihood_mask_list=None, compute_bool=None,
+                 kwargs_pixelbased=None, linear_solver=True):
         """
 
         :param multi_band_list: list of imaging band configurations [[kwargs_data, kwargs_psf, kwargs_numerics],[...], ...]
         :param kwargs_model: model option keyword arguments
         :param likelihood_mask_list: list of likelihood masks (booleans with size of the individual images)
         :param compute_bool: (optional), bool list to indicate which band to be included in the modeling
+        :param linear_solver: bool, if True (default) fixes the linear amplitude parameters 'amp' (avoid sampling) such
+         that they get overwritten by the linear solver solution.
         """
         self.type = 'multi-linear'
         imageModel_list = []
+        if linear_solver is False and len(multi_band_list) > 1:
+            raise ValueError('Multi-linear mode with more than one band does not support "linear_solver" = False.')
         for band_index in range(len(multi_band_list)):
             imageModel = SingleBandMultiModel(multi_band_list, kwargs_model, likelihood_mask_list=likelihood_mask_list,
-                                              band_index=band_index, kwargs_pixelbased=kwargs_pixelbased)
+                                              band_index=band_index, kwargs_pixelbased=kwargs_pixelbased,
+                                              linear_solver=linear_solver)
             imageModel_list.append(imageModel)
         super(MultiLinear, self).__init__(imageModel_list, compute_bool=compute_bool)
 

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -25,14 +25,18 @@ class SingleBandMultiModel(ImageLinearFit):
 
     """
 
-    def __init__(self, multi_band_list, kwargs_model, likelihood_mask_list=None, band_index=0, kwargs_pixelbased=None):
+    def __init__(self, multi_band_list, kwargs_model, likelihood_mask_list=None, band_index=0, kwargs_pixelbased=None,
+                 linear_solver=True):
         """
 
         :param multi_band_list: list of imaging band configurations [[kwargs_data, kwargs_psf, kwargs_numerics],[...], ...]
         :param kwargs_model: model option keyword arguments
         :param likelihood_mask_list: list of likelihood masks (booleans with size of the individual images
         :param band_index: integer, index of the imaging band to model
-        :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver (see SLITronomy documentation)
+        :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver
+         (see SLITronomy documentation)
+        :param linear_solver: bool, if True (default) fixes the linear amplitude parameters 'amp' (avoid sampling) such
+         that they get overwritten by the linear solver solution.
         """
         self.type = 'single-band-multi-model'
         if likelihood_mask_list is None:
@@ -55,6 +59,7 @@ class SingleBandMultiModel(ImageLinearFit):
         index_optical_depth = kwargs_model.get('index_optical_depth_model_list',
                                                    [None for i in range(len(multi_band_list))])
         self._index_optical_depth = index_optical_depth[band_index]
+        self._linear_solver = linear_solver
 
         super(SingleBandMultiModel, self).__init__(data_i, psf_i, lens_model_class, source_model_class,
                                                    lens_light_model_class, point_source_class, extinction_class,
@@ -106,7 +111,8 @@ class SingleBandMultiModel(ImageLinearFit):
                                                                                               kwargs_extinction)
         logL = self._likelihood_data_given_model(kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i,
                                                  kwargs_extinction_i, kwargs_special, source_marg=source_marg,
-                                                 linear_prior=linear_prior, check_positive_flux=check_positive_flux)
+                                                 linear_prior=linear_prior, check_positive_flux=check_positive_flux,
+                                                 linear_solver=self._linear_solver)
         return logL
 
     def num_param_linear(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None):
@@ -114,6 +120,8 @@ class SingleBandMultiModel(ImageLinearFit):
 
         :return: number of linear coefficients to be solved for in the linear inversion
         """
+        if self._linear_solver is False:
+            return 0
         kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps)
         num = self._num_param_linear(kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i)
         return num

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -29,14 +29,13 @@ class ImageLinearFit(ImageModel):
         :param kwargs_numerics: keyword arguments passed to the Numerics module
         :param likelihood_mask: 2d boolean array of pixels to be counted in the likelihood calculation/linear optimization
         :param psf_error_map_bool_list: list of boolean of length of point source models. Indicates whether PSF error map
-        :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver (see SLITronomy documentation)
-        being applied to the point sources.
+        :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver
+         (see SLITronomy documentation) being applied to the point sources.
         """
         if likelihood_mask is None:
             likelihood_mask = np.ones_like(data_class.data)
         self.likelihood_mask = np.array(likelihood_mask, dtype=bool)
         self._mask1d = util.image2array(self.likelihood_mask)
-        # kwargs_numerics['compute_indexes'] = self.likelihood_mask  # here we overwrite the indexes to be computed with the likelihood mask
         super(ImageLinearFit, self).__init__(data_class, psf_class=psf_class, lens_model_class=lens_model_class,
                                              source_model_class=source_model_class,
                                              lens_light_model_class=lens_light_model_class,
@@ -191,7 +190,7 @@ class ImageLinearFit(ImageModel):
 
     def _likelihood_data_given_model(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
                                      kwargs_extinction=None, kwargs_special=None, source_marg=False, linear_prior=None,
-                                     check_positive_flux=False):
+                                     check_positive_flux=False, linear_solver=True):
         """
 
         computes the likelihood of the data given a model
@@ -205,6 +204,8 @@ class ImageLinearFit(ImageModel):
         :param linear_prior: linear prior width in eigenvalues
         :param check_positive_flux: bool, if True, checks whether the linear inversion resulted in non-negative flux
          components and applies a punishment in the likelihood if so.
+        :param linear_solver: bool, if True (default) fixes the linear amplitude parameters 'amp' (avoid sampling) such
+         that they get overwritten by the linear solver solution.
         :return: log likelihood (natural logarithm)
         """
         # generate image

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -27,8 +27,10 @@ class ImageLinearFit(ImageModel):
         :param lens_light_model_class: LightModel() instance
         :param point_source_class: PointSource() instance
         :param kwargs_numerics: keyword arguments passed to the Numerics module
-        :param likelihood_mask: 2d boolean array of pixels to be counted in the likelihood calculation/linear optimization
-        :param psf_error_map_bool_list: list of boolean of length of point source models. Indicates whether PSF error map
+        :param likelihood_mask: 2d boolean array of pixels to be counted in the likelihood calculation/linear
+         optimization
+        :param psf_error_map_bool_list: list of boolean of length of point source models.
+         Indicates whether PSF error map is used for the point source model stated as the index.
         :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver
          (see SLITronomy documentation) being applied to the point sources.
         """
@@ -158,11 +160,12 @@ class ImageLinearFit(ImageModel):
         """
         returns the 1d array of the error estimate corresponding to the data response
 
-        :return: 1d numpy array of response, 2d array of additonal errors (e.g. point source uncertainties)
+        :return: 1d numpy array of response, 2d array of additional errors (e.g. point source uncertainties)
         """
-        psf_model_error = self._error_map_psf(kwargs_lens, kwargs_ps, kwargs_special=kwargs_special)
-        C_D_response = self.image2array_masked(self.Data.C_D + psf_model_error)
-        return C_D_response, psf_model_error
+        model_error = self._error_map_model(kwargs_lens, kwargs_ps, kwargs_special=kwargs_special)
+        # adding the uncertainties estimated from the data with the ones from the model
+        C_D_response = self.image2array_masked(self.Data.C_D + model_error)
+        return C_D_response, model_error
 
     def likelihood_data_given_model(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
                                     kwargs_extinction=None, kwargs_special=None, source_marg=False, linear_prior=None,
@@ -209,9 +212,16 @@ class ImageLinearFit(ImageModel):
         :return: log likelihood (natural logarithm)
         """
         # generate image
-        im_sim, model_error, cov_matrix, param = self._image_linear_solve(kwargs_lens, kwargs_source, kwargs_lens_light,
-                                                                          kwargs_ps, kwargs_extinction, kwargs_special,
-                                                                          inv_bool=source_marg)
+        if linear_solver is False:
+            im_sim = self.image(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction,
+                                kwargs_special)
+            cov_matrix = None
+            model_error = self._error_map_model(kwargs_lens, kwargs_ps=kwargs_ps, kwargs_special=kwargs_special)
+        else:
+            im_sim, model_error, cov_matrix, param = self._image_linear_solve(kwargs_lens, kwargs_source,
+                                                                              kwargs_lens_light, kwargs_ps,
+                                                                              kwargs_extinction, kwargs_special,
+                                                                              inv_bool=source_marg)
         # compute X^2
         logL = self.Data.log_likelihood(im_sim, self.likelihood_mask, model_error)
 
@@ -394,12 +404,26 @@ class ImageLinearFit(ImageModel):
         grid2d = util.array2image(grid1d, nx, ny)
         return grid2d
 
+    def _error_map_model(self, kwargs_lens, kwargs_ps, kwargs_special=None):
+        """
+        noise estimate (variances as diagonal of the pixel covariance matrix) resulted from inherent model uncertainties
+        This term is currently the psf error map
+
+        :param kwargs_lens: lens model keyword arguments
+        :param kwargs_ps: point source keyword arguments
+        :param kwargs_special: special parameter keyword arguments
+        :return: 2d array corresponding to the pixels in terms of variance in noise
+        """
+        return self._error_map_psf(kwargs_lens, kwargs_ps, kwargs_special)
+
     def _error_map_psf(self, kwargs_lens, kwargs_ps, kwargs_special=None):
         """
+        map of image with error terms (sigma**2) expected from inaccuracies in the PSF modeling
 
-        :param kwargs_lens:
-        :param kwargs_ps:
-        :return:
+        :param kwargs_lens: lens model keyword arguments
+        :param kwargs_ps: point source keyword arguments
+        :param kwargs_special: special parameter keyword arguments
+        :return: 2d array of size of the image
         """
         error_map = np.zeros(self.Data.num_pixel_axes)
         if self._psf_error_map is True:

--- a/lenstronomy/Plots/model_plot.py
+++ b/lenstronomy/Plots/model_plot.py
@@ -19,7 +19,7 @@ class ModelPlot(object):
     """
     def __init__(self, multi_band_list, kwargs_model, kwargs_params, image_likelihood_mask_list=None,
                  bands_compute=None, multi_band_type='multi-linear', source_marg=False, linear_prior=None,
-                 arrow_size=0.02, cmap_string="gist_heat", fast_caustic=True):
+                 arrow_size=0.02, cmap_string="gist_heat", fast_caustic=True, linear_solver=True):
         """
 
         :param multi_band_list: list of [[kwargs_data, kwargs_psf, kwargs_numerics], [], ..]
@@ -39,13 +39,15 @@ class ModelPlot(object):
         :param arrow_size:
         :param cmap_string:
         :param fast_caustic: boolean; if True, uses fast (but less accurate) caustic calculation method
+        :param linear_solver: bool, if True (default) fixes the linear amplitude parameters 'amp' (avoid sampling) such
+         that they get overwritten by the linear solver solution.
         """
         if bands_compute is None:
             bands_compute = [True] * len(multi_band_list)
         if multi_band_type == 'single-band':
             multi_band_type = 'multi-linear'  # this makes sure that the linear inversion outputs are coming in a list
         self._imageModel = class_creator.create_im_sim(multi_band_list, multi_band_type, kwargs_model,
-                                                       bands_compute=bands_compute,
+                                                       bands_compute=bands_compute, linear_solver=linear_solver,
                                                        image_likelihood_mask_list=image_likelihood_mask_list)
 
         model, error_map, cov_param, param = self._imageModel.image_linear_solve(inv_bool=True, **kwargs_params)

--- a/lenstronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/image_likelihood.py
@@ -11,7 +11,7 @@ class ImageLikelihood(object):
 
     def __init__(self, multi_band_list, multi_band_type, kwargs_model, bands_compute=None,
                  image_likelihood_mask_list=None, source_marg=False, linear_prior=None, check_positive_flux=False,
-                 kwargs_pixelbased=None):
+                 kwargs_pixelbased=None, linear_solver=True):
         """
 
         :param bands_compute: list of bools with same length as data objects, indicates which "band" to include in the
@@ -26,11 +26,13 @@ class ImageLikelihood(object):
          parameters
         :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver
          (see SLITronomy documentation)
+        :param linear_solver: bool, if True (default) fixes the linear amplitude parameters 'amp' (avoid sampling) such
+         that they get overwritten by the linear solver solution.
         """
         self.imSim = class_creator.create_im_sim(multi_band_list, multi_band_type, kwargs_model,
                                                  bands_compute=bands_compute,
                                                  image_likelihood_mask_list=image_likelihood_mask_list,
-                                                 kwargs_pixelbased=kwargs_pixelbased)
+                                                 kwargs_pixelbased=kwargs_pixelbased, linear_solver=linear_solver)
         self._model_type = self.imSim.type
         self._source_marg = source_marg
         self._linear_prior = linear_prior

--- a/lenstronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/image_likelihood.py
@@ -79,6 +79,6 @@ class ImageLikelihood(object):
         """
 
         :param cache: boolean
-        :return:
+        :return: None
         """
         self.imSim.reset_point_source_cache(cache=cache)

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -95,6 +95,7 @@ class LikelihoodModule(object):
         self._flux_ratio_likelihood = flux_ratio_likelihood
         if kwargs_flux_compute is None:
             kwargs_flux_compute = {}
+        linear_solver = self.param.linear_solver
         self._kwargs_flux_compute = kwargs_flux_compute
         self._check_bounds = check_bounds
         self._custom_logL_addition = custom_logL_addition
@@ -104,7 +105,7 @@ class LikelihoodModule(object):
                                 'bands_compute': bands_compute,
                                 'image_likelihood_mask_list': image_likelihood_mask_list, 'source_marg': source_marg,
                                 'linear_prior': linear_prior, 'check_positive_flux': check_positive_flux,
-                                'kwargs_pixelbased': kwargs_pixelbased}
+                                'kwargs_pixelbased': kwargs_pixelbased, 'linear_solver': linear_solver}
         self._kwargs_position = {'astrometric_likelihood': astrometric_likelihood,
                                  'image_position_likelihood': image_position_likelihood,
                                  'source_position_likelihood': source_position_likelihood,

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -279,10 +279,24 @@ class Param(object):
             if i_source in self._image_plane_source_list:
                 raise ValueError("linking a source light model with a lens model AND simultaneously parameterizing the"
                                  " source position in the image plane is not valid!")
+        self._linear_solver = linear_solver
 
     @property
     def num_point_source_images(self):
+        """
+
+        :return: total number of point source images
+        """
         return self._num_images
+
+    @property
+    def linear_solver(self):
+        """
+        boolean to state whether linear solver is activated or not
+
+        :return: boolean
+        """
+        return self._linear_solver
 
     def args2kwargs(self, args, bijective=False):
         """

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -258,9 +258,9 @@ class Param(object):
         self.lensLightParams = LightParam(self._lens_light_model_list, kwargs_fixed_lens_light_updated, param_type='lens_light',
                                           linear_solver=linear_solver, kwargs_lower=kwargs_lower_lens_light,
                                           kwargs_upper=kwargs_upper_lens_light)
-        self.souceParams = LightParam(self._source_light_model_list, kwargs_fixed_source_updated, param_type='source_light',
-                                      linear_solver=linear_solver, kwargs_lower=kwargs_lower_source,
-                                      kwargs_upper=kwargs_upper_source)
+        self.sourceParams = LightParam(self._source_light_model_list, kwargs_fixed_source_updated, param_type='source_light',
+                                       linear_solver=linear_solver, kwargs_lower=kwargs_lower_source,
+                                       kwargs_upper=kwargs_upper_source)
         self.pointSourceParams = PointSourceParam(self._point_source_model_list, kwargs_fixed_ps_updated,
                                                   num_point_source_list=num_point_source_list,
                                                   linear_solver=linear_solver, kwargs_lower=kwargs_lower_ps,
@@ -297,7 +297,7 @@ class Param(object):
         i = 0
         args = np.atleast_1d(args)
         kwargs_lens, i = self.lensParams.get_params(args, i)
-        kwargs_source, i = self.souceParams.get_params(args, i)
+        kwargs_source, i = self.sourceParams.get_params(args, i)
         kwargs_lens_light, i = self.lensLightParams.get_params(args, i)
         kwargs_ps, i = self.pointSourceParams.get_params(args, i)
         kwargs_special, i = self.specialParams.get_params(args, i)
@@ -347,7 +347,7 @@ class Param(object):
         """
 
         args = self.lensParams.set_params(kwargs_lens)
-        args += self.souceParams.set_params(kwargs_source)
+        args += self.sourceParams.set_params(kwargs_source)
         args += self.lensLightParams.set_params(kwargs_lens_light)
         args += self.pointSourceParams.set_params(kwargs_ps)
         args += self.specialParams.set_params(kwargs_special)
@@ -360,13 +360,13 @@ class Param(object):
         :return: lower and upper limits of the arguments being sampled
         """
         lower_limit = self.kwargs2args(kwargs_lens=self.lensParams.lower_limit,
-                                       kwargs_source=self.souceParams.lower_limit,
+                                       kwargs_source=self.sourceParams.lower_limit,
                                        kwargs_lens_light=self.lensLightParams.lower_limit,
                                        kwargs_ps=self.pointSourceParams.lower_limit,
                                        kwargs_special=self.specialParams.lower_limit,
                                        kwargs_extinction=self.extinctionParams.lower_limit)
         upper_limit = self.kwargs2args(kwargs_lens=self.lensParams.upper_limit,
-                                       kwargs_source=self.souceParams.upper_limit,
+                                       kwargs_source=self.sourceParams.upper_limit,
                                        kwargs_lens_light=self.lensLightParams.upper_limit,
                                        kwargs_ps=self.pointSourceParams.upper_limit,
                                        kwargs_special=self.specialParams.upper_limit,
@@ -379,7 +379,7 @@ class Param(object):
         :return: number of parameters involved (int), list of parameter names
         """
         num, name_list = self.lensParams.num_param()
-        _num, _list = self.souceParams.num_param()
+        _num, _list = self.sourceParams.num_param()
         num += _num
         name_list += _list
         _num, _list = self.lensLightParams.num_param()
@@ -402,7 +402,7 @@ class Param(object):
         :return: number of linear basis set coefficients that are solved for
         """
         num = 0
-        num += self.souceParams.num_param_linear()
+        num += self.sourceParams.num_param_linear()
         num += self.lensLightParams.num_param_linear()
         num += self.pointSourceParams.num_param_linear()
         return num
@@ -634,7 +634,7 @@ class Param(object):
         print("===================")
         print("The following parameters are being fixed:")
         print("Lens:", self.lensParams.kwargs_fixed)
-        print("Source:", self.souceParams.kwargs_fixed)
+        print("Source:", self.sourceParams.kwargs_fixed)
         print("Lens light:", self.lensLightParams.kwargs_fixed)
         print("Point source:", self.pointSourceParams.kwargs_fixed)
         print("===================")

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -177,7 +177,7 @@ def create_image_model(kwargs_data, kwargs_psf, kwargs_numerics, kwargs_model, i
 
 @export
 def create_im_sim(multi_band_list, multi_band_type, kwargs_model, bands_compute=None, image_likelihood_mask_list=None,
-                  band_index=0, kwargs_pixelbased=None):
+                  band_index=0, kwargs_pixelbased=None, linear_solver=True):
     """
 
 
@@ -192,9 +192,12 @@ def create_im_sim(multi_band_list, multi_band_type, kwargs_model, bands_compute=
      (same size as image_data with 1 indicating being evaluated and 0 being left out)
     :param band_index: integer, index of the imaging band to model (only applied when using 'single-band' as option)
     :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver (see SLITronomy documentation)
-
+    :param linear_solver: bool, if True (default) fixes the linear amplitude parameters 'amp' (avoid sampling) such
+     that they get overwritten by the linear solver solution.
     :return: MultiBand class instance
     """
+    if linear_solver is False and multi_band_type is not 'single-band':
+        raise ValueError('setting "linear_solver" to False is only supported in "single-band" mode.')
 
     if multi_band_type == 'multi-linear':
         from lenstronomy.ImSim.MultiBand.multi_linear import MultiLinear
@@ -205,7 +208,8 @@ def create_im_sim(multi_band_list, multi_band_type, kwargs_model, bands_compute=
     elif multi_band_type == 'single-band':
         from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
         multiband = SingleBandMultiModel(multi_band_list, kwargs_model, likelihood_mask_list=image_likelihood_mask_list,
-                                         band_index=band_index, kwargs_pixelbased=kwargs_pixelbased)
+                                         band_index=band_index, kwargs_pixelbased=kwargs_pixelbased,
+                                         linear_solver=linear_solver)
     else:
         raise ValueError("type %s is not supported!" % multi_band_type)
     return multiband

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -196,15 +196,18 @@ def create_im_sim(multi_band_list, multi_band_type, kwargs_model, bands_compute=
      that they get overwritten by the linear solver solution.
     :return: MultiBand class instance
     """
-    if linear_solver is False and multi_band_type is not 'single-band':
-        raise ValueError('setting "linear_solver" to False is only supported in "single-band" mode.')
+    if linear_solver is False and multi_band_type not in ['single-band', 'multi-linear']:
+        raise ValueError('setting "linear_solver" to False is only supported in "single-band" mode '
+                         'or if "multi-linear" model has only one band.')
 
     if multi_band_type == 'multi-linear':
         from lenstronomy.ImSim.MultiBand.multi_linear import MultiLinear
-        multiband = MultiLinear(multi_band_list, kwargs_model, compute_bool=bands_compute, likelihood_mask_list=image_likelihood_mask_list)
+        multiband = MultiLinear(multi_band_list, kwargs_model, compute_bool=bands_compute,
+                                likelihood_mask_list=image_likelihood_mask_list, linear_solver=linear_solver)
     elif multi_band_type == 'joint-linear':
         from lenstronomy.ImSim.MultiBand.joint_linear import JointLinear
-        multiband = JointLinear(multi_band_list, kwargs_model, compute_bool=bands_compute, likelihood_mask_list=image_likelihood_mask_list)
+        multiband = JointLinear(multi_band_list, kwargs_model, compute_bool=bands_compute,
+                                likelihood_mask_list=image_likelihood_mask_list)
     elif multi_band_type == 'single-band':
         from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
         multiband = SingleBandMultiModel(multi_band_list, kwargs_model, likelihood_mask_list=image_likelihood_mask_list,

--- a/lenstronomy/Workflow/fitting_sequence.py
+++ b/lenstronomy/Workflow/fitting_sequence.py
@@ -201,7 +201,7 @@ class FittingSequence(object):
         kwargs_result = param_class.args2kwargs(result, bijective=True)
         return kwargs_result
 
-    def mcmc(self, n_burn, n_run, walkerRatio, n_walkers=None, sigma_scale=1, threadCount=1, init_samples=None,
+    def mcmc(self, n_burn, n_run, walkerRatio=None, n_walkers=None, sigma_scale=1, threadCount=1, init_samples=None,
              re_use_samples=True, sampler_type='EMCEE', progress=True, backend_filename=None, start_from_backend=False):
         """
         MCMC routine
@@ -235,6 +235,8 @@ class FittingSequence(object):
         sigma_start = np.array(param_class.kwargs2args(**kwargs_sigma)) * sigma_scale
         num_param, param_list = param_class.num_param()
         if n_walkers is None:
+            if walkerRatio is None:
+                raise ValueError('MCMC sampler needs either n_walkser or walkerRatio as input argument')
             n_walkers = num_param * walkerRatio
         # run MCMC
         if init_samples is not None and re_use_samples is True:

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -1,0 +1,98 @@
+import pytest
+import numpy.testing as npt
+
+from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
+
+from lenstronomy.Util import simulation_util
+from lenstronomy.ImSim.image_model import ImageModel
+from lenstronomy.LensModel.lens_model import LensModel
+from lenstronomy.LightModel.light_model import LightModel
+from lenstronomy.PointSource.point_source import PointSource
+from lenstronomy.Data.imaging_data import ImageData
+from lenstronomy.Data.psf import PSF
+
+
+class TestSingleBandMultiModel(object):
+
+    def setup(self):
+        # data specifics
+        sigma_bkg = 0.05  # background noise per pixel
+        exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
+        numPix = 10  # cutout pixel size
+        deltaPix = 0.1  # pixel size in arcsec (area per pixel = deltaPix**2)
+        fwhm = 0.5  # full width half max of PSF
+
+        # PSF specification
+
+        kwargs_data = simulation_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
+        data_class = ImageData(**kwargs_data)
+        kwargs_psf = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix}
+        psf_class = PSF(**kwargs_psf)
+        kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}
+
+        lens_model_list = ['SPEP']
+        kwargs_lens = [kwargs_spemd]
+        lens_model_class = LensModel(lens_model_list=lens_model_list)
+        kwargs_sersic = {'amp': 1., 'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
+        # 'SERSIC_ELLIPSE': elliptical Sersic profile
+        kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0,
+                                 'e1': 0.1, 'e2': 0.1}
+
+        lens_light_model_list = ['SERSIC']
+        kwargs_lens_light = [kwargs_sersic]
+        lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
+        source_model_list = ['SERSIC_ELLIPSE']
+        kwargs_source = [kwargs_sersic_ellipse]
+        source_model_class = LightModel(light_model_list=source_model_list)
+
+        # Point Source
+        point_source_model_list = ['UNLENSED']
+        kwargs_ps = [{'ra_image': [0.4], 'dec_image': [-0.2], 'point_amp': [2]}]
+        point_source_class = PointSource(point_source_type_list=point_source_model_list)
+
+        kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False, 'compute_mode': 'regular'}
+        imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class,
+                                lens_light_model_class, point_source_class=point_source_class,
+                                kwargs_numerics=kwargs_numerics)
+        image_sim = simulation_util.simulate_simple(imageModel, kwargs_lens, kwargs_source, kwargs_lens_light,
+                                                    kwargs_ps)
+
+        data_class.update_data(image_sim)
+        kwargs_data['image_data'] = image_sim
+        self.multi_band_list = [[kwargs_data, kwargs_psf, kwargs_numerics]]
+
+        self.kwargs_model = {'lens_model_list': lens_model_list,
+                        'source_light_model_list': source_model_list,
+                        'lens_light_model_list': lens_light_model_list,
+                        'point_source_model_list': point_source_model_list,
+                        'fixed_magnification_list': [False],
+                        'index_lens_model_list': [[0]],
+                        'index_lens_light_model_list': [[0]],
+                        'index_source_light_model_list': [[0]],
+                        'index_point_source_model_list': [[0]],
+                        }
+
+        self.kwargs_params = {'kwargs_lens': kwargs_lens, 'kwargs_source': kwargs_source,
+                              'kwargs_lens_light': kwargs_lens_light, 'kwargs_ps': kwargs_ps}
+
+        self.single_band = SingleBandMultiModel(multi_band_list=self.multi_band_list, kwargs_model=self.kwargs_model,
+                                                linear_solver=True)
+        self.single_band_no_linear = SingleBandMultiModel(multi_band_list=self.multi_band_list,
+                                                          kwargs_model=self.kwargs_model,
+                                                          linear_solver=False)
+
+    def test_likelihood_data_given_model(self):
+
+        logl = self.single_band.likelihood_data_given_model(**self.kwargs_params)
+        logl_no_linear = self.single_band_no_linear.likelihood_data_given_model(**self.kwargs_params)
+        npt.assert_almost_equal(logl / logl_no_linear, 1, decimal=4)
+
+    def test_num_param_linear(self):
+        num_linear = self.single_band.num_param_linear(**self.kwargs_params)
+        assert num_linear == 3
+        num_linear = self.single_band_no_linear.num_param_linear(**self.kwargs_params)
+        assert num_linear == 0
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_time_delay_likelihood.py
@@ -80,9 +80,6 @@ class TestImageLikelihood(object):
                                                  lens_model_class=lensModel, point_source_class=pointSource)
         logL = td_likelihood.logL(kwargs_lens=kwargs_lens, kwargs_ps=kwargs_ps, kwargs_cosmo=kwargs_cosmo)
         npt.assert_almost_equal(logL, -10**15, decimal=8)
-        
-
-
 
 
 if __name__ == '__main__':

--- a/test/test_Sampling/test_Samplers/conftest.py
+++ b/test/test_Sampling/test_Samplers/conftest.py
@@ -1,0 +1,92 @@
+# conftest.py
+import pytest
+
+import lenstronomy.Util.simulation_util as sim_util
+from lenstronomy.ImSim.image_model import ImageModel
+from lenstronomy.Sampling.likelihood import LikelihoodModule
+from lenstronomy.Sampling.parameters import Param
+from lenstronomy.LensModel.lens_model import LensModel
+from lenstronomy.LightModel.light_model import LightModel
+from lenstronomy.Data.imaging_data import ImageData
+from lenstronomy.Data.psf import PSF
+
+
+@pytest.fixture
+def simple_einstein_ring_likelihood():
+
+    # data specifics
+    sigma_bkg = 0.05  # background noise per pixel
+    exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
+    numPix = 10  # cutout pixel size
+    deltaPix = 0.1  # pixel size in arcsec (area per pixel = deltaPix**2)
+    fwhm = 0.5  # full width half max of PSF
+
+    # PSF specification
+
+    kwargs_data = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
+    data_class = ImageData(**kwargs_data)
+    kwargs_psf_gaussian = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix}
+    psf = PSF(**kwargs_psf_gaussian)
+    kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': psf.kernel_point_source}
+    psf_class = PSF(**kwargs_psf)
+    kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}
+
+    lens_model_list = ['SPEP']
+    kwargs_lens = [kwargs_spemd]
+    lens_model_class = LensModel(lens_model_list=lens_model_list)
+    kwargs_sersic = {'amp': 1., 'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
+    # 'SERSIC_ELLIPSE': elliptical Sersic profile
+    kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0,
+                             'e1': 0.1, 'e2': 0.1}
+
+    lens_light_model_list = ['SERSIC']
+    kwargs_lens_light = [kwargs_sersic]
+    lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
+    source_model_list = ['SERSIC_ELLIPSE']
+    kwargs_source = [kwargs_sersic_ellipse]
+    source_model_class = LightModel(light_model_list=source_model_list)
+
+    kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False, 'compute_mode': 'regular'}
+    imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class,
+                            lens_light_model_class, kwargs_numerics=kwargs_numerics)
+    image_sim = sim_util.simulate_simple(imageModel, kwargs_lens, kwargs_source,
+                                         kwargs_lens_light)
+
+    data_class.update_data(image_sim)
+    kwargs_data['image_data'] = image_sim
+    kwargs_data_joint = {'multi_band_list': [[kwargs_data, kwargs_psf, kwargs_numerics]], 'multi_band_type': 'single-band'}
+
+    kwargs_model = {'lens_model_list': lens_model_list,
+                    'source_light_model_list': source_model_list,
+                    'lens_light_model_list': lens_light_model_list,
+                    'fixed_magnification_list': [False],
+                    }
+
+    kwargs_constraints = {'image_plane_source_list': [False] * len(source_model_list)}
+
+    kwargs_likelihood = {'source_marg': False,
+                         'image_position_uncertainty': 0.004,
+                         'check_matched_source_position': False,
+                         'source_position_tolerance': 0.001,
+                         'source_position_sigma': 0.001,
+                         }
+
+    # reduce number of param to sample (for runtime)
+    kwargs_fixed_lens = [{'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
+    kwargs_lower_lens = [{'theta_E': 0.8}]
+    kwargs_upper_lens = [{'theta_E': 1.2}]
+    kwargs_fixed_source = [{'R_sersic': 0.6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
+    kwargs_fixed_lens_light = [{'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}]
+
+    param_class = Param(kwargs_model,
+                             kwargs_fixed_lens=kwargs_fixed_lens,
+                             kwargs_fixed_source=kwargs_fixed_source,
+                             kwargs_fixed_lens_light=kwargs_fixed_lens_light,
+                             kwargs_lower_lens=kwargs_lower_lens,
+                             kwargs_upper_lens=kwargs_upper_lens,
+                             **kwargs_constraints)
+
+    likelihood = LikelihoodModule(kwargs_data_joint=kwargs_data_joint, kwargs_model=kwargs_model,
+                                       param_class=param_class, **kwargs_likelihood)
+    kwargs_truths = {'kwargs_lens': kwargs_lens, 'kwargs_source': kwargs_source, 'kwargs_lens_light': kwargs_lens_light}
+    return likelihood, kwargs_truths

--- a/test/test_Sampling/test_Samplers/test_base_nested_sampler.py
+++ b/test/test_Sampling/test_Samplers/test_base_nested_sampler.py
@@ -2,17 +2,22 @@ __author__ = 'aymgal'
 
 import pytest
 import numpy as np
-import numpy.testing as npt
-import lenstronomy.Util.simulation_util as sim_util
-from lenstronomy.ImSim.image_model import ImageModel
-from lenstronomy.Sampling.likelihood import LikelihoodModule
-from lenstronomy.Sampling.parameters import Param
-from lenstronomy.LensModel.lens_model import LensModel
-from lenstronomy.LightModel.light_model import LightModel
-from lenstronomy.Data.imaging_data import ImageData
-from lenstronomy.Data.psf import PSF
 
 from lenstronomy.Sampling.Samplers.base_nested_sampler import NestedSampler
+
+
+@pytest.fixture
+def import_fixture(simple_einstein_ring_likelihood):
+    """
+
+    :param simple_einstein_ring_likelihood: fixture
+    :return:
+    """
+    likelihood, kwargs_truths = simple_einstein_ring_likelihood
+    prior_means = likelihood.param.kwargs2args(**kwargs_truths)
+    prior_sigmas = np.ones_like(prior_means) * 0.1
+    sampler = NestedSampler(likelihood, 'gaussian', prior_means, prior_sigmas, 0.5, 0.5)
+    return sampler, likelihood
 
 
 class TestNestedSampler(object):
@@ -22,123 +27,43 @@ class TestNestedSampler(object):
 
     def setup(self):
 
-        # data specifics
-        sigma_bkg = 0.05  # background noise per pixel
-        exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
-        numPix = 10  # cutout pixel size
-        deltaPix = 0.1  # pixel size in arcsec (area per pixel = deltaPix**2)
-        fwhm = 0.5  # full width half max of PSF
+        pass
 
-        # PSF specification
-
-        kwargs_data = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
-        data_class = ImageData(**kwargs_data)
-        kwargs_psf_gaussian = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix}
-        psf = PSF(**kwargs_psf_gaussian)
-        kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': psf.kernel_point_source}
-        psf_class = PSF(**kwargs_psf)
-        kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}
-
-        lens_model_list = ['SPEP']
-        self.kwargs_lens = [kwargs_spemd]
-        lens_model_class = LensModel(lens_model_list=lens_model_list)
-        kwargs_sersic = {'amp': 1., 'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
-        # 'SERSIC_ELLIPSE': elliptical Sersic profile
-        kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0,
-                                 'e1': 0.1, 'e2': 0.1}
-
-        lens_light_model_list = ['SERSIC']
-        self.kwargs_lens_light = [kwargs_sersic]
-        lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
-        source_model_list = ['SERSIC_ELLIPSE']
-        self.kwargs_source = [kwargs_sersic_ellipse]
-        source_model_class = LightModel(light_model_list=source_model_list)
-
-        kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False, 'compute_mode': 'regular'}
-        imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class,
-                                lens_light_model_class, kwargs_numerics=kwargs_numerics)
-        image_sim = sim_util.simulate_simple(imageModel, self.kwargs_lens, self.kwargs_source,
-                                         self.kwargs_lens_light)
-
-        data_class.update_data(image_sim)
-        kwargs_data['image_data'] = image_sim
-        kwargs_data_joint = {'multi_band_list': [[kwargs_data, kwargs_psf, kwargs_numerics]], 'multi_band_type': 'single-band'}
-        self.data_class = data_class
-        self.psf_class = psf_class
-
-        kwargs_model = {'lens_model_list': lens_model_list,
-                             'source_light_model_list': source_model_list,
-                             'lens_light_model_list': lens_light_model_list,
-                             'fixed_magnification_list': [False],
-                             }
-        self.kwargs_numerics = {
-            'subgrid_res': 1,
-            'psf_subgrid': False}
-
-        kwargs_constraints = {'image_plane_source_list': [False] * len(source_model_list)}
-
-        kwargs_likelihood = {'source_marg': False,
-                             'image_position_uncertainty': 0.004,
-                             'check_matched_source_position': False,
-                             'source_position_tolerance': 0.001,
-                             'source_position_sigma': 0.001,
-                             }
-
-        # reduce number of param to sample (for runtime)
-        kwargs_fixed_lens = [{'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
-        kwargs_lower_lens = [{'theta_E': 0.8}]
-        kwargs_upper_lens = [{'theta_E': 1.2}]
-        kwargs_fixed_source = [{'R_sersic': 0.6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
-        kwargs_fixed_lens_light = [{'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}]
-
-        self.param_class = Param(kwargs_model,
-                                 kwargs_fixed_lens=kwargs_fixed_lens,
-                                 kwargs_fixed_source=kwargs_fixed_source,
-                                 kwargs_fixed_lens_light=kwargs_fixed_lens_light,
-                                 kwargs_lower_lens=kwargs_lower_lens,
-                                 kwargs_upper_lens=kwargs_upper_lens,
-                                 **kwargs_constraints)
-
-        self.Likelihood = LikelihoodModule(kwargs_data_joint=kwargs_data_joint, kwargs_model=kwargs_model,
-                                           param_class=self.param_class, **kwargs_likelihood)
-
-        prior_means = self.param_class.kwargs2args(kwargs_lens=self.kwargs_lens, kwargs_source=self.kwargs_source,
-                                                   kwargs_lens_light=self.kwargs_lens_light)
-        prior_sigmas = np.ones_like(prior_means) * 0.1
-        self.sampler = NestedSampler(self.Likelihood, 'gaussian',
-                                     prior_means, prior_sigmas, 0.5, 0.5)
-
-    def test_sampler(self):
+    def test_sampler(self, import_fixture):
+        sampler, likelihood = import_fixture
         kwargs_run = {}
         try:
-            self.sampler.run(kwargs_run)
+            sampler.run(kwargs_run)
         except Exception as e:
             assert isinstance(e, NotImplementedError)
 
-    def test_sampler_init(self):
-        sampler = NestedSampler(self.Likelihood, 'uniform', None, None, 1, 1)
+    def test_sampler_init(self, import_fixture):
+        _, likelihood = import_fixture
+        sampler = NestedSampler(likelihood, 'uniform', None, None, 1, 1)
         try:
-            sampler = NestedSampler(self.Likelihood, 'gaussian', None, None, 1, 1) # will raise an Error 
+            sampler = NestedSampler(likelihood, 'gaussian', None, None, 1, 1) # will raise an Error
         except Exception as e:
             assert isinstance(e, ValueError)
         try:
-            sampler = NestedSampler(self.Likelihood, 'some_type', None, None, 1, 1) # will raise an Error 
+            sampler = NestedSampler(likelihood, 'some_type', None, None, 1, 1) # will raise an Error
         except Exception as e:
             assert isinstance(e, ValueError)
 
-    def test_prior(self):
-        n_dims = self.sampler.n_dims
+    def test_prior(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         cube = np.zeros(n_dims)
         try:
-            self.sampler.prior(cube)
+            sampler.prior(cube)
         except Exception as e:
             assert isinstance(e, NotImplementedError)
 
-    def test_log_likelihood(self):
-        n_dims = self.sampler.n_dims
+    def test_log_likelihood(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         args = np.nan * np.ones(n_dims)
         try:
-            self.sampler.log_likelihood(args)
+            sampler.log_likelihood(args)
         except Exception as e:
             assert isinstance(e, NotImplementedError)
 

--- a/test/test_Sampling/test_Samplers/test_dynesty_sampler.py
+++ b/test/test_Sampling/test_Samplers/test_dynesty_sampler.py
@@ -3,16 +3,25 @@ __author__ = 'aymgal'
 import pytest
 import numpy as np
 import numpy.testing as npt
-import lenstronomy.Util.simulation_util as sim_util
-from lenstronomy.ImSim.image_model import ImageModel
-from lenstronomy.Sampling.likelihood import LikelihoodModule
-from lenstronomy.Sampling.parameters import Param
-from lenstronomy.LensModel.lens_model import LensModel
-from lenstronomy.LightModel.light_model import LightModel
-from lenstronomy.Data.imaging_data import ImageData
-from lenstronomy.Data.psf import PSF
 
 from lenstronomy.Sampling.Samplers.dynesty_sampler import DynestySampler
+
+
+@pytest.fixture
+def import_fixture(simple_einstein_ring_likelihood):
+    """
+
+    :param simple_einstein_ring_likelihood: fixture
+    :return:
+    """
+    likelihood, kwargs_truths = simple_einstein_ring_likelihood
+    prior_means = likelihood.param.kwargs2args(**kwargs_truths)
+    prior_sigmas = np.ones_like(prior_means) * 0.1
+    sampler = DynestySampler(likelihood, prior_type='uniform',
+                             prior_means=prior_means,
+                             prior_sigmas=prior_sigmas,
+                             sigma_scale=0.5)
+    return sampler, likelihood
 
 
 class TestDynestySampler(object):
@@ -21,96 +30,10 @@ class TestDynestySampler(object):
     """
 
     def setup(self):
+        pass
 
-        # data specifics
-        sigma_bkg = 0.05  # background noise per pixel
-        exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
-        numPix = 10  # cutout pixel size
-        deltaPix = 0.1  # pixel size in arcsec (area per pixel = deltaPix**2)
-        fwhm = 0.5  # full width half max of PSF
-
-        # PSF specification
-
-        kwargs_data = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
-        data_class = ImageData(**kwargs_data)
-        kwargs_psf_gaussian = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix}
-        psf = PSF(**kwargs_psf_gaussian)
-        kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': psf.kernel_point_source}
-        psf_class = PSF(**kwargs_psf)
-        kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}
-
-        lens_model_list = ['SPEP']
-        self.kwargs_lens = [kwargs_spemd]
-        lens_model_class = LensModel(lens_model_list=lens_model_list)
-        kwargs_sersic = {'amp': 1., 'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
-        # 'SERSIC_ELLIPSE': elliptical Sersic profile
-        kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0,
-                                 'e1': 0.1, 'e2': 0.1}
-
-        lens_light_model_list = ['SERSIC']
-        self.kwargs_lens_light = [kwargs_sersic]
-        lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
-        source_model_list = ['SERSIC_ELLIPSE']
-        self.kwargs_source = [kwargs_sersic_ellipse]
-        source_model_class = LightModel(light_model_list=source_model_list)
-
-        kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False, 'compute_mode': 'regular'}
-        imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class,
-                                lens_light_model_class, kwargs_numerics=kwargs_numerics)
-        image_sim = sim_util.simulate_simple(imageModel, self.kwargs_lens, self.kwargs_source,
-                                         self.kwargs_lens_light)
-
-        data_class.update_data(image_sim)
-        kwargs_data['image_data'] = image_sim
-        kwargs_data_joint = {'multi_band_list': [[kwargs_data, kwargs_psf, kwargs_numerics]], 'multi_band_type': 'single-band'}
-        self.data_class = data_class
-        self.psf_class = psf_class
-
-        kwargs_model = {'lens_model_list': lens_model_list,
-                             'source_light_model_list': source_model_list,
-                             'lens_light_model_list': lens_light_model_list,
-                             'fixed_magnification_list': [False],
-                             }
-        self.kwargs_numerics = {
-            'subgrid_res': 1,
-            'psf_subgrid': False}
-
-        kwargs_constraints = {'image_plane_source_list': [False] * len(source_model_list)}
-
-        kwargs_likelihood = {'source_marg': False,
-                             'image_position_uncertainty': 0.004,
-                             'check_matched_source_position': False,
-                             'source_position_tolerance': 0.001,
-                             'source_position_sigma': 0.001,
-                             }
-
-        # reduce number of param to sample (for runtime)
-        kwargs_fixed_lens = [{'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
-        kwargs_lower_lens = [{'theta_E': 0.8}]
-        kwargs_upper_lens = [{'theta_E': 1.2}]
-        kwargs_fixed_source = [{'R_sersic': 0.6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
-        kwargs_fixed_lens_light = [{'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}]
-
-        self.param_class = Param(kwargs_model,
-                                 kwargs_fixed_lens=kwargs_fixed_lens,
-                                 kwargs_fixed_source=kwargs_fixed_source,
-                                 kwargs_fixed_lens_light=kwargs_fixed_lens_light,
-                                 kwargs_lower_lens=kwargs_lower_lens,
-                                 kwargs_upper_lens=kwargs_upper_lens,
-                                 **kwargs_constraints)
-
-        self.Likelihood = LikelihoodModule(kwargs_data_joint=kwargs_data_joint, kwargs_model=kwargs_model,
-                                           param_class=self.param_class, **kwargs_likelihood)
-
-        prior_means = self.param_class.kwargs2args(kwargs_lens=self.kwargs_lens, kwargs_source=self.kwargs_source,
-                                                   kwargs_lens_light=self.kwargs_lens_light)
-        prior_sigmas = np.ones_like(prior_means) * 0.1
-        self.sampler = DynestySampler(self.Likelihood, prior_type='uniform',
-                                      prior_means=prior_means, 
-                                      prior_sigmas=prior_sigmas,
-                                      sigma_scale=0.5)
-
-    def test_sampler(self):
+    def test_sampler(self, import_fixture):
+        sampler, likelihood = import_fixture
         kwargs_run = {
             'dlogz_init': 0.01,
             'nlive_init': 4,
@@ -118,42 +41,45 @@ class TestDynestySampler(object):
             'maxbatch': 1,
             'wt_kwargs': {'pfrac': 0.8},
         }
-        samples, means, logZ, logZ_err, logL, results = self.sampler.run(kwargs_run)
+        samples, means, logZ, logZ_err, logL, results = sampler.run(kwargs_run)
         assert len(means) == 1
 
-    def test_sampler_init(self):
+    def test_sampler_init(self, import_fixture):
+        sampler, likelihood = import_fixture
         try:
-            sampler = DynestySampler(self.Likelihood, prior_type='gaussian',
-                                       prior_means=None, # will raise an Error 
-                                       prior_sigmas=None) # will raise an Error
+            sampler = DynestySampler(likelihood, prior_type='gaussian',
+                                     prior_means=None, # will raise an Error
+                                     prior_sigmas=None) # will raise an Error
         except Exception as e:
             assert isinstance(e, ValueError)
         try:
-            sampler = DynestySampler(self.Likelihood, prior_type='some_type')
+            sampler = DynestySampler(likelihood, prior_type='some_type')
         except Exception as e:
             assert isinstance(e, ValueError)
 
-    def test_prior(self):
-        n_dims = self.sampler.n_dims
+    def test_prior(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         cube_low = np.zeros(n_dims)
         cube_upp = np.ones(n_dims)
 
         self.prior_type = 'uniform'
-        cube_low = self.sampler.prior(cube_low)
-        npt.assert_equal(cube_low, self.sampler.lowers)
-        cube_upp = self.sampler.prior(cube_upp)
-        npt.assert_equal(cube_upp, self.sampler.uppers)
+        cube_low = sampler.prior(cube_low)
+        npt.assert_equal(cube_low, sampler.lowers)
+        cube_upp = sampler.prior(cube_upp)
+        npt.assert_equal(cube_upp, sampler.uppers)
 
         cube_mid = 0.5 * np.ones(n_dims)
         self.prior_type = 'gaussian'
-        self.sampler.prior(cube_mid)
+        sampler.prior(cube_mid)
         cube_gauss = np.array([0.5])
         npt.assert_equal(cube_mid, cube_gauss)
 
-    def test_log_likelihood(self):
-        n_dims = self.sampler.n_dims
+    def test_log_likelihood(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         args = np.nan * np.ones(n_dims)
-        logL = self.sampler.log_likelihood(args)
+        logL = sampler.log_likelihood(args)
         assert logL < 0
         #npt.assert_almost_equal(logL, -47.167446538898204)
         #assert logL == -1e15

--- a/test/test_Sampling/test_Samplers/test_multinest_sampler.py
+++ b/test/test_Sampling/test_Samplers/test_multinest_sampler.py
@@ -5,14 +5,6 @@ import os
 import shutil
 import numpy as np
 import numpy.testing as npt
-import lenstronomy.Util.simulation_util as sim_util
-from lenstronomy.ImSim.image_model import ImageModel
-from lenstronomy.Sampling.likelihood import LikelihoodModule
-from lenstronomy.Sampling.parameters import Param
-from lenstronomy.LensModel.lens_model import LensModel
-from lenstronomy.LightModel.light_model import LightModel
-from lenstronomy.Data.imaging_data import ImageData
-from lenstronomy.Data.psf import PSF
 
 from lenstronomy.Sampling.Samplers.multinest_sampler import MultiNestSampler
 
@@ -26,6 +18,27 @@ else:
     pymultinest_installed = True
 
 
+_output_dir = 'test_nested_out'
+
+
+@pytest.fixture
+def import_fixture(simple_einstein_ring_likelihood):
+    """
+
+    :param simple_einstein_ring_likelihood: fixture
+    :return:
+    """
+    likelihood, kwargs_truths = simple_einstein_ring_likelihood
+    prior_means = likelihood.param.kwargs2args(**kwargs_truths)
+    prior_sigmas = np.ones_like(prior_means) * 0.1
+    sampler = MultiNestSampler(likelihood, prior_type='uniform',
+                               prior_means=prior_means,
+                               prior_sigmas=prior_sigmas,
+                               output_dir=_output_dir,
+                               remove_output_dir=True)
+    return sampler, likelihood
+
+
 class TestMultiNestSampler(object):
     """
     test the fitting sequences
@@ -33,82 +46,10 @@ class TestMultiNestSampler(object):
 
     def setup(self):
 
-        # data specifics
-        sigma_bkg = 0.05  # background noise per pixel
-        exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
-        numPix = 10  # cutout pixel size
-        deltaPix = 0.1  # pixel size in arcsec (area per pixel = deltaPix**2)
-        fwhm = 0.5  # full width half max of PSF
+        pass
 
-        # PSF specification
-
-        kwargs_data = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
-        data_class = ImageData(**kwargs_data)
-        kwargs_psf_gaussian = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix}
-        psf = PSF(**kwargs_psf_gaussian)
-        kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': psf.kernel_point_source}
-        psf_class = PSF(**kwargs_psf)
-        kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}
-
-        lens_model_list = ['SPEP']
-        self.kwargs_lens = [kwargs_spemd]
-        lens_model_class = LensModel(lens_model_list=lens_model_list)
-        kwargs_sersic = {'amp': 1., 'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
-        # 'SERSIC_ELLIPSE': elliptical Sersic profile
-        kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0,
-                                 'e1': 0.1, 'e2': 0.1}
-
-        lens_light_model_list = ['SERSIC']
-        self.kwargs_lens_light = [kwargs_sersic]
-        lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
-        source_model_list = ['SERSIC_ELLIPSE']
-        self.kwargs_source = [kwargs_sersic_ellipse]
-        source_model_class = LightModel(light_model_list=source_model_list)
-
-        kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False, 'compute_mode': 'regular'}
-        imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class,
-                                lens_light_model_class, kwargs_numerics=kwargs_numerics)
-        image_sim = sim_util.simulate_simple(imageModel, self.kwargs_lens, self.kwargs_source,
-                                         self.kwargs_lens_light)
-
-        data_class.update_data(image_sim)
-        kwargs_data['image_data'] = image_sim
-        kwargs_data_joint = {'multi_band_list': [[kwargs_data, kwargs_psf, kwargs_numerics]], 'multi_band_type': 'single-band'}
-        self.data_class = data_class
-        self.psf_class = psf_class
-
-        kwargs_model = {'lens_model_list': lens_model_list,
-                             'source_light_model_list': source_model_list,
-                             'lens_light_model_list': lens_light_model_list,
-                             'fixed_magnification_list': [False],
-                             }
-        self.kwargs_numerics = {
-            'subgrid_res': 1,
-            'psf_subgrid': False}
-
-        kwargs_constraints = {'image_plane_source_list': [False] * len(source_model_list)}
-
-        kwargs_likelihood = {'source_marg': False,
-                             'image_position_uncertainty': 0.004,
-                             'check_matched_source_position': False,
-                             'source_position_tolerance': 0.001,
-                             'source_position_sigma': 0.001,
-                             }
-        self.param_class = Param(kwargs_model, **kwargs_constraints)
-        self.Likelihood = LikelihoodModule(kwargs_data_joint=kwargs_data_joint, kwargs_model=kwargs_model,
-                                           param_class=self.param_class, **kwargs_likelihood)
-
-        prior_means = self.param_class.kwargs2args(kwargs_lens=self.kwargs_lens, kwargs_source=self.kwargs_source,
-                                                   kwargs_lens_light=self.kwargs_lens_light)
-        prior_sigmas = np.ones_like(prior_means) * 0.1
-        self.output_dir = 'test_nested_out'
-        self.sampler = MultiNestSampler(self.Likelihood, prior_type='uniform',
-                                        prior_means=prior_means, 
-                                        prior_sigmas=prior_sigmas,
-                                        output_dir=self.output_dir,
-                                        remove_output_dir=True)
-
-    def test_sampler(self):
+    def test_sampler(self, import_fixture):
+        sampler, likelihood = import_fixture
         kwargs_run = {
             'n_live_points': 10,
             'evidence_tolerance': 0.5,
@@ -117,22 +58,23 @@ class TestMultiNestSampler(object):
             'multimodal': True,
             'const_efficiency_mode': False,   # reduce sampling_efficiency to 5% when True
         }
-        samples, means, logZ, logZ_err, logL, results = self.sampler.run(kwargs_run)
-        assert len(means) == 16
+        samples, means, logZ, logZ_err, logL, results = sampler.run(kwargs_run)
+        assert len(means) == 1
         if not pymultinest_installed:
             # trivial test when pymultinest is not installed properly
             assert np.count_nonzero(samples) == 0
-        if os.path.exists(self.output_dir):
-            shutil.rmtree(self.output_dir, ignore_errors=True)
+        if os.path.exists(_output_dir):
+            shutil.rmtree(_output_dir, ignore_errors=True)
 
-    def test_sampler_init(self):
+    def test_sampler_init(self, import_fixture):
+        sampler, likelihood = import_fixture
         test_dir = 'some_dir'
         os.mkdir(test_dir)
-        sampler = MultiNestSampler(self.Likelihood, prior_type='uniform',
+        sampler = MultiNestSampler(likelihood, prior_type='uniform',
                                    output_dir=test_dir)
         shutil.rmtree(test_dir, ignore_errors=True)
         try:
-            sampler = MultiNestSampler(self.Likelihood, prior_type='gaussian',
+            sampler = MultiNestSampler(likelihood, prior_type='gaussian',
                                        prior_means=None, # will raise an Error 
                                        prior_sigmas=None, # will raise an Error
                                        output_dir=None,
@@ -140,32 +82,33 @@ class TestMultiNestSampler(object):
         except Exception as e:
             assert isinstance(e, ValueError)
         try:
-            sampler = MultiNestSampler(self.Likelihood, prior_type='some_type')
+            sampler = MultiNestSampler(likelihood, prior_type='some_type')
         except Exception as e:
             assert isinstance(e, ValueError)
 
-    def test_prior(self):
-        n_dims = self.sampler.n_dims
+    def test_prior(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         cube_low = np.zeros(n_dims)
         cube_upp = np.ones(n_dims)
 
         self.prior_type = 'uniform'
-        self.sampler.prior(cube_low, n_dims, n_dims)
-        npt.assert_equal(cube_low, self.sampler.lowers)
-        self.sampler.prior(cube_upp, n_dims, n_dims)
-        npt.assert_equal(cube_upp, self.sampler.uppers)
+        sampler.prior(cube_low, n_dims, n_dims)
+        npt.assert_equal(cube_low, sampler.lowers)
+        sampler.prior(cube_upp, n_dims, n_dims)
+        npt.assert_equal(cube_upp, sampler.uppers)
 
         cube_mid = 0.5 * np.ones(n_dims)
         self.prior_type = 'gaussian'
-        self.sampler.prior(cube_mid, n_dims, n_dims)
-        cube_gauss = np.array([50., 50., 0., 0., 0., 0., 50., 4.25, 
-                                0., 0., 0., 0., 50., 4.25, 0., 0.])
+        sampler.prior(cube_mid, n_dims, n_dims)
+        cube_gauss = np.array([1.0])
         npt.assert_equal(cube_mid, cube_gauss)
 
-    def test_log_likelihood(self):
-        n_dims = self.sampler.n_dims
+    def test_log_likelihood(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         args = np.nan * np.ones(n_dims)
-        logL = self.sampler.log_likelihood(args, n_dims, n_dims)
+        logL = sampler.log_likelihood(args, n_dims, n_dims)
         assert logL < 0
         #npt.assert_almost_equal(logL, -53.24465641401431, decimal=8)
         #assert logL == -1e15

--- a/test/test_Sampling/test_Samplers/test_polychord_sampler.py
+++ b/test/test_Sampling/test_Samplers/test_polychord_sampler.py
@@ -5,14 +5,6 @@ import os
 import shutil
 import numpy as np
 import numpy.testing as npt
-import lenstronomy.Util.simulation_util as sim_util
-from lenstronomy.ImSim.image_model import ImageModel
-from lenstronomy.Sampling.likelihood import LikelihoodModule
-from lenstronomy.Sampling.parameters import Param
-from lenstronomy.LensModel.lens_model import LensModel
-from lenstronomy.LightModel.light_model import LightModel
-from lenstronomy.Data.imaging_data import ImageData
-from lenstronomy.Data.psf import PSF
 
 from lenstronomy.Sampling.Samplers.polychord_sampler import DyPolyChordSampler
 
@@ -36,6 +28,26 @@ else:
  
 all_installed = dypolychord_installed and nestcheck_installed
 
+_output_dir = 'test_nested_out'
+
+
+@pytest.fixture
+def import_fixture(simple_einstein_ring_likelihood):
+    """
+
+    :param simple_einstein_ring_likelihood: fixture
+    :return:
+    """
+    likelihood, kwargs_truths = simple_einstein_ring_likelihood
+    prior_means = likelihood.param.kwargs2args(**kwargs_truths)
+    prior_sigmas = np.ones_like(prior_means) * 0.1
+    sampler = DyPolyChordSampler(likelihood, prior_type='uniform',
+                                 prior_means=prior_means,
+                                 prior_sigmas=prior_sigmas,
+                                 output_dir=_output_dir,
+                                 remove_output_dir=True)
+    return sampler, likelihood
+
 
 class TestDyPolyChordSampler(object):
     """
@@ -44,117 +56,32 @@ class TestDyPolyChordSampler(object):
 
     def setup(self):
 
-        # data specifics
-        sigma_bkg = 0.05  # background noise per pixel
-        exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
-        numPix = 10  # cutout pixel size
-        deltaPix = 0.1  # pixel size in arcsec (area per pixel = deltaPix**2)
-        fwhm = 0.5  # full width half max of PSF
+        pass
 
-        # PSF specification
-
-        kwargs_data = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
-        data_class = ImageData(**kwargs_data)
-        kwargs_psf_gaussian = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix}
-        psf = PSF(**kwargs_psf_gaussian)
-        kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': psf.kernel_point_source}
-        psf_class = PSF(**kwargs_psf)
-        kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}
-
-        lens_model_list = ['SPEP']
-        self.kwargs_lens = [kwargs_spemd]
-        lens_model_class = LensModel(lens_model_list=lens_model_list)
-        kwargs_sersic = {'amp': 1., 'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
-        # 'SERSIC_ELLIPSE': elliptical Sersic profile
-        kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0,
-                                 'e1': 0.1, 'e2': 0.1}
-
-        lens_light_model_list = ['SERSIC']
-        self.kwargs_lens_light = [kwargs_sersic]
-        lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
-        source_model_list = ['SERSIC_ELLIPSE']
-        self.kwargs_source = [kwargs_sersic_ellipse]
-        source_model_class = LightModel(light_model_list=source_model_list)
-
-        kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False, 'compute_mode': 'regular'}
-        imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class,
-                                lens_light_model_class, kwargs_numerics=kwargs_numerics)
-        image_sim = sim_util.simulate_simple(imageModel, self.kwargs_lens, self.kwargs_source,
-                                         self.kwargs_lens_light)
-
-        data_class.update_data(image_sim)
-        kwargs_data['image_data'] = image_sim
-        kwargs_data_joint = {'multi_band_list': [[kwargs_data, kwargs_psf, kwargs_numerics]], 'multi_band_type': 'single-band'}
-        self.data_class = data_class
-        self.psf_class = psf_class
-
-        kwargs_model = {'lens_model_list': lens_model_list,
-                             'source_light_model_list': source_model_list,
-                             'lens_light_model_list': lens_light_model_list,
-                             'fixed_magnification_list': [False],
-                             }
-        self.kwargs_numerics = {
-            'subgrid_res': 1,
-            'psf_subgrid': False}
-
-        kwargs_constraints = {'image_plane_source_list': [False] * len(source_model_list)}
-
-        kwargs_likelihood = {'source_marg': False,
-                             'image_position_uncertainty': 0.004,
-                             'check_matched_source_position': False,
-                             'source_position_tolerance': 0.001,
-                             'source_position_sigma': 0.001,
-                                  }
-        # reduce number of param to sample (for runtime)
-        kwargs_fixed_lens = [{'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
-        kwargs_lower_lens = [{'theta_E': 0.8}]
-        kwargs_upper_lens = [{'theta_E': 1.2}]
-        kwargs_fixed_source = [{'R_sersic': 0.6, 'n_sersic': 3, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.1}]
-        kwargs_fixed_lens_light = [{'R_sersic': 0.1, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}]
-
-        self.param_class = Param(kwargs_model,
-                                 kwargs_fixed_lens=kwargs_fixed_lens,
-                                 kwargs_fixed_source=kwargs_fixed_source,
-                                 kwargs_fixed_lens_light=kwargs_fixed_lens_light,
-                                 kwargs_lower_lens=kwargs_lower_lens,
-                                 kwargs_upper_lens=kwargs_upper_lens,
-                                 **kwargs_constraints)
-
-        self.Likelihood = LikelihoodModule(kwargs_data_joint=kwargs_data_joint, kwargs_model=kwargs_model,
-                                           param_class=self.param_class, **kwargs_likelihood)
-
-        prior_means = self.param_class.kwargs2args(kwargs_lens=self.kwargs_lens, kwargs_source=self.kwargs_source,
-                                                  kwargs_lens_light=self.kwargs_lens_light)
-        prior_sigmas = np.ones_like(prior_means) * 0.1
-        self.output_dir = 'test_nested_out'
-        self.sampler = DyPolyChordSampler(self.Likelihood, prior_type='uniform',
-                                          prior_means=prior_means, 
-                                          prior_sigmas=prior_sigmas,
-                                          output_dir=self.output_dir,
-                                          remove_output_dir=True)
-
-    def test_sampler(self):
+    def test_sampler(self, import_fixture):
+        sampler, likelihood = import_fixture
         kwargs_run = {
             'ninit': 2, 
             'nlive_const': 3,
         }
         dynamic_goal = 0.8
-        samples, means, logZ, logZ_err, logL, results = self.sampler.run(dynamic_goal, kwargs_run)
+        samples, means, logZ, logZ_err, logL, results = sampler.run(dynamic_goal, kwargs_run)
         assert len(means) == 1
         if not all_installed:
             # trivial test when dypolychord is not installed properly
             assert np.count_nonzero(samples) == 0
-        if os.path.exists(self.output_dir):
-            shutil.rmtree(self.output_dir, ignore_errors=True)
+        if os.path.exists(_output_dir):
+            shutil.rmtree(_output_dir, ignore_errors=True)
 
-    def test_sampler_init(self):
+    def test_sampler_init(self, import_fixture):
+        sampler, likelihood = import_fixture
         test_dir = 'some_dir'
         os.mkdir(test_dir)
-        sampler = DyPolyChordSampler(self.Likelihood, prior_type='uniform',
+        sampler = DyPolyChordSampler(likelihood, prior_type='uniform',
                                      output_dir=test_dir)
         shutil.rmtree(test_dir, ignore_errors=True)
         try:
-            sampler = DyPolyChordSampler(self.Likelihood, prior_type='gaussian',
+            sampler = DyPolyChordSampler(likelihood, prior_type='gaussian',
                                          prior_means=None, # will raise an Error 
                                          prior_sigmas=None, # will raise an Error
                                          output_dir=None,
@@ -162,37 +89,40 @@ class TestDyPolyChordSampler(object):
         except Exception as e:
             assert isinstance(e, ValueError)
         try:
-            sampler = DyPolyChordSampler(self.Likelihood, prior_type='some_type')
+            sampler = DyPolyChordSampler(likelihood, prior_type='some_type')
         except Exception as e:
             assert isinstance(e, ValueError)
 
-    def test_prior(self):
-        n_dims = self.sampler.n_dims
+    def test_prior(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         cube_low = np.zeros(n_dims)
         cube_upp = np.ones(n_dims)
 
         self.prior_type = 'uniform'
-        cube_low = self.sampler.prior(cube_low)
-        npt.assert_equal(cube_low, self.sampler.lowers)
-        cube_upp = self.sampler.prior(cube_upp)
-        npt.assert_equal(cube_upp, self.sampler.uppers)
+        cube_low = sampler.prior(cube_low)
+        npt.assert_equal(cube_low, sampler.lowers)
+        cube_upp = sampler.prior(cube_upp)
+        npt.assert_equal(cube_upp, sampler.uppers)
 
         cube_mid = 0.5 * np.ones(n_dims)
         self.prior_type = 'gaussian'
-        self.sampler.prior(cube_mid)
+        sampler.prior(cube_mid)
         cube_gauss = np.array([0.5])
         npt.assert_equal(cube_mid, cube_gauss)
 
-    def test_log_likelihood(self):
-        n_dims = self.sampler.n_dims
+    def test_log_likelihood(self, import_fixture):
+        sampler, likelihood = import_fixture
+        n_dims = sampler.n_dims
         args = np.nan * np.ones(n_dims)
-        logL, phi = self.sampler.log_likelihood(args)
+        logL, phi = sampler.log_likelihood(args)
         assert logL < 0
         #npt.assert_almost_equal(logL, -53.607122396369675, decimal=8)
         #assert logL == -1e15
         assert phi == []
 
-    def test_write_equal_weights(self):
+    def test_write_equal_weights(self, import_fixture):
+        sampler, likelihood = import_fixture
         n_dims = 10
         ns_run = {
             'theta': np.zeros((1, n_dims)),
@@ -203,7 +133,7 @@ class TestDyPolyChordSampler(object):
                 'param_means': np.zeros(n_dims)
             }
         }
-        self.sampler._write_equal_weights(ns_run['theta'], ns_run['logl'])
+        sampler._write_equal_weights(ns_run['theta'], ns_run['logl'])
 
 
 if __name__ == '__main__':

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -85,6 +85,9 @@ class TestRaise(unittest.TestCase):
         with self.assertRaises(ValueError):
             class_creator.create_im_sim(multi_band_list=None, multi_band_type='WRONG', kwargs_model=None,
                                         bands_compute=None, image_likelihood_mask_list=None, band_index=0)
+        with self.assertRaises(ValueError):
+            class_creator.create_im_sim(multi_band_list=[[], []], multi_band_type='multi-linear', linear_solver=False,
+                                        kwargs_model=None, bands_compute=None, image_likelihood_mask_list=None, band_index=0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Propagating option to switch off linear inversion for 'amp' parameters such that the user is enabled to sample the 'amp' parameter in the non-linear parameters.

The design is such that if in the kwargs_constraints of the Param() class setting, the keyword linear_solver=False is set, then the 'amp' parameters are being tracked in the sampler and the likelihood module creates an instance where no linear inversion is being made in the execution of the likelihood. This currently only works in single-band modeling.